### PR TITLE
Association format

### DIFF
--- a/ChatGPTPluginKit/Documentation/English/Guides/ChatGPTPluginKit.nb
+++ b/ChatGPTPluginKit/Documentation/English/Guides/ChatGPTPluginKit.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     11735,        307]
-NotebookOptionsPosition[      7728,        220]
-NotebookOutlinePosition[      8658,        246]
-CellTagsIndexPosition[      8615,        243]
+NotebookDataLength[     11694,        305]
+NotebookOptionsPosition[      7691,        218]
+NotebookOutlinePosition[      8617,        244]
+CellTagsIndexPosition[      8574,        241]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -43,8 +43,8 @@ Cell[TextData[{
  Cell[BoxData[
   ButtonBox["ChatGPTPlugin",
    BaseStyle->"Link",
-   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPlugin"]],
-   "InlineGuideFunction",
+   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPlugin"]], 
+  "InlineGuideFunction",
   TaggingRules->{"PageType" -> "Function"},
   CellTags->"c40ac8e4-27e1-4161-a8df-4d4f38357a23",ExpressionUUID->
   "cad4f665-21a9-4497-a51d-ade5cc0a6a69"],
@@ -59,8 +59,7 @@ Cell[TextData[{
  Cell[BoxData[
   ButtonBox["ChatGPTPluginEndpoint",
    BaseStyle->"Link",
-   ButtonData->
-    "paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginEndpoint"]], 
+   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginEndpoint"]], 
   "InlineGuideFunction",
   TaggingRules->{"PageType" -> "Function"},
   CellTags->"c5c6736a-1ff4-4e4e-8fcf-2d9846cbae62",ExpressionUUID->
@@ -75,8 +74,7 @@ Cell[TextData[{
  Cell[BoxData[
   ButtonBox["ChatGPTPluginDeploy",
    BaseStyle->"Link",
-   ButtonData->
-    "paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginDeploy"]], 
+   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginDeploy"]], 
   "InlineGuideFunction",
   TaggingRules->{"PageType" -> "Function"},
   CellTags->"c90df6b6-99e7-4eba-ae75-f768f67078e7",ExpressionUUID->
@@ -105,10 +103,10 @@ Cell[TextData[{
     "b1fde370-1818-46a9-9156-446d4faa368a"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "8d263370-70e1-4edf-9814-2cdfe8000c26", 
-     "240fe19c-ed47-4c25-b7a9-b445ab3da67d"], $CellContext`cellobj$$ = 
+     "245f8390-ebb0-4288-a1f6-233e6fb6f533"], $CellContext`cellobj$$ = 
     CellObject[
     "1bafe79f-b594-4410-b98b-7ef1a0a81599", 
-     "4b25337e-6f00-4741-8001-1d6453a9029f"]}, 
+     "53db6b25-de99-48ba-b1c0-f11ca54b33ef"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -229,7 +227,7 @@ TaggingRules->{
     "$UseNewPageDialog" -> ""}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "Wolfram/ChatGPTPluginKit"},
-FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
+FrontEndVersion->"13.3 for Mac OS X x86 (64-bit) (April 8, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "GuidePageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"8d263370-70e1-4edf-9814-2cdfe8000c26"
@@ -254,62 +252,64 @@ Cell[763, 26, 390, 7, 47, "GuideAbstract",ExpressionUUID->"e67747be-03bf-4bb8-84
 Cell[CellGroupData[{
 Cell[1190, 38, 109, 1, 72, "GuideFunctionsSection",ExpressionUUID->"05384643-2e5c-4b5d-a791-e67d5ede8bfe",
  CellID->1745511157],
-Cell[1302, 41, 644, 14, 27, "GuideText",ExpressionUUID->"864a183e-2feb-493b-a253-ff7cc485b8ad",
+Cell[1302, 41, 635, 14, 27, "GuideText",ExpressionUUID->"864a183e-2feb-493b-a253-ff7cc485b8ad",
  CellID->31914032],
-Cell[1949, 57, 630, 14, 27, "GuideText",ExpressionUUID->"43fbf19f-410d-4bd1-ba8f-06e899fc0910",
+Cell[1940, 57, 616, 13, 27, "GuideText",ExpressionUUID->"43fbf19f-410d-4bd1-ba8f-06e899fc0910",
  CellID->1655707721],
-Cell[2582, 73, 581, 13, 27, "GuideText",ExpressionUUID->"c6d6e456-d90c-4c46-bac3-819791d70f59",
+Cell[2559, 72, 567, 12, 27, "GuideText",ExpressionUUID->"c6d6e456-d90c-4c46-bac3-819791d70f59",
  CellID->1873694747],
 Cell[CellGroupData[{
-Cell[3188, 90, 104, 1, 27, "GuideDelimiter",ExpressionUUID->"29abd819-1bbe-4ac9-bec0-999427dd8134",
+Cell[3151, 88, 104, 1, 27, "GuideDelimiter",ExpressionUUID->"29abd819-1bbe-4ac9-bec0-999427dd8134",
  CellID->1013889632],
-Cell[3295, 93, 1810, 44, 27, "InlineGuideFunctionListing",ExpressionUUID->"c027d326-bad4-46f6-b19b-897dc5821552",
+Cell[3258, 91, 1810, 44, 27, "InlineGuideFunctionListing",ExpressionUUID->"c027d326-bad4-46f6-b19b-897dc5821552",
  CellID->852661928]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[5154, 143, 119, 1, 74, "GuideTutorialsSection",ExpressionUUID->"44cd7134-10c4-4e9c-bc2e-fbba6c0427bb",
+Cell[5117, 141, 119, 1, 74, "GuideTutorialsSection",ExpressionUUID->"44cd7134-10c4-4e9c-bc2e-fbba6c0427bb",
  CellID->2119586078],
-Cell[5276, 146, 105, 1, 24, "GuideTutorial",ExpressionUUID->"c5acee5d-38df-4b8f-9812-7f4324025f79",
+Cell[5239, 144, 105, 1, 24, "GuideTutorial",ExpressionUUID->"c5acee5d-38df-4b8f-9812-7f4324025f79",
  CellID->1424476510],
-Cell[5384, 149, 105, 1, 24, "GuideTutorial",ExpressionUUID->"d6536eaf-7596-49e8-9e58-92dfa4bd044b",
+Cell[5347, 147, 105, 1, 24, "GuideTutorial",ExpressionUUID->"d6536eaf-7596-49e8-9e58-92dfa4bd044b",
  CellID->1029006814]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[5526, 155, 190, 2, 74, "GuideMoreAboutSection",ExpressionUUID->"2290eda2-f76a-4ee5-bb4b-cf374578e3ab",
+Cell[5489, 153, 190, 2, 74, "GuideMoreAboutSection",ExpressionUUID->"2290eda2-f76a-4ee5-bb4b-cf374578e3ab",
  CellID->831713607],
-Cell[5719, 159, 105, 1, 24, "GuideMoreAbout",ExpressionUUID->"4904f3b8-087d-45b7-bc4f-4c804451f98f",
+Cell[5682, 157, 105, 1, 24, "GuideMoreAbout",ExpressionUUID->"4904f3b8-087d-45b7-bc4f-4c804451f98f",
  CellID->639534526],
-Cell[5827, 162, 105, 1, 24, "GuideMoreAbout",ExpressionUUID->"f0d83f08-1c0d-4428-8d29-ee8ac8159954",
+Cell[5790, 160, 105, 1, 24, "GuideMoreAbout",ExpressionUUID->"f0d83f08-1c0d-4428-8d29-ee8ac8159954",
  CellID->501125247]
 }, Open  ]],
-Cell[5947, 166, 125, 1, 74, "GuideRelatedLinksSection",ExpressionUUID->"c8c52101-4142-473a-9386-c1849211e6a4",
+Cell[5910, 164, 125, 1, 74, "GuideRelatedLinksSection",ExpressionUUID->"c8c52101-4142-473a-9386-c1849211e6a4",
  CellID->2128646442],
 Cell[CellGroupData[{
-Cell[6097, 171, 111, 1, 72, "MetadataSection",ExpressionUUID->"5284a271-0deb-4895-b295-e46589fa474d",
+Cell[6060, 169, 111, 1, 72, "MetadataSection",ExpressionUUID->"5284a271-0deb-4895-b295-e46589fa474d",
  CellID->1230675321],
-Cell[6211, 174, 477, 12, 26, "History",ExpressionUUID->"fa213b1c-6886-4377-bb98-f01767dca08f",
+Cell[6174, 172, 477, 12, 26, "History",ExpressionUUID->"fa213b1c-6886-4377-bb98-f01767dca08f",
  CellID->1545115790],
 Cell[CellGroupData[{
-Cell[6713, 190, 123, 1, 21, "CategorizationSection",ExpressionUUID->"b7c1f2a9-e4dd-4ee2-a1db-2dee2c41c3b9",
+Cell[6676, 188, 123, 1, 21, "CategorizationSection",ExpressionUUID->"b7c1f2a9-e4dd-4ee2-a1db-2dee2c41c3b9",
  CellID->1388823006],
-Cell[6839, 193, 133, 2, 35, "Categorization",ExpressionUUID->"cdb4bca9-fe73-4b92-86b1-31ea03392e84",
+Cell[6802, 191, 133, 2, 70, "Categorization",ExpressionUUID->"cdb4bca9-fe73-4b92-86b1-31ea03392e84",
  CellID->948502599],
-Cell[6975, 197, 152, 2, 35, "Categorization",ExpressionUUID->"797a2868-0a59-488c-854a-098fa8baae8e",
+Cell[6938, 195, 152, 2, 70, "Categorization",ExpressionUUID->"797a2868-0a59-488c-854a-098fa8baae8e",
  CellID->712069712],
-Cell[7130, 201, 150, 2, 35, "Categorization",ExpressionUUID->"bbcf70ed-246b-40a2-8cc6-137f335b83d8",
+Cell[7093, 199, 150, 2, 70, "Categorization",ExpressionUUID->"bbcf70ed-246b-40a2-8cc6-137f335b83d8",
  CellID->1976768500],
-Cell[7283, 205, 168, 2, 35, "Categorization",ExpressionUUID->"047db68a-a92e-4dc8-8978-d017e3d3003b",
+Cell[7246, 203, 168, 2, 70, "Categorization",ExpressionUUID->"047db68a-a92e-4dc8-8978-d017e3d3003b",
  CellID->1976160410]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7488, 212, 110, 1, 31, "KeywordsSection",ExpressionUUID->"8d600f9f-45db-4fe9-a485-69f6d4c9de13",
+Cell[7451, 210, 110, 1, 70, "KeywordsSection",ExpressionUUID->"8d600f9f-45db-4fe9-a485-69f6d4c9de13",
  CellID->345926368],
-Cell[7601, 215, 99, 1, 70, "Keywords",ExpressionUUID->"6c092148-21e9-4d2e-aac1-9eec0f442654",
+Cell[7564, 213, 99, 1, 70, "Keywords",ExpressionUUID->"6c092148-21e9-4d2e-aac1-9eec0f442654",
  CellID->746234547]
 }, Closed]]
 }, Open  ]]
 }
 ]
 *)
+
+(* End of internal cache information *)
 

--- a/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPlugin.nb
+++ b/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPlugin.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     73523,       1611]
-NotebookOptionsPosition[     65855,       1450]
-NotebookOutlinePosition[     67021,       1483]
-CellTagsIndexPosition[     66941,       1478]
+NotebookDataLength[     89029,       1947]
+NotebookOptionsPosition[     80575,       1770]
+NotebookOutlinePosition[     81737,       1803]
+CellTagsIndexPosition[     81657,       1798]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -47,9 +47,41 @@ Cell[TextData[{
        StyleBox["2", "TR"]], ",", 
       StyleBox["\[Ellipsis]", "TR"]}], "}"}]}], "]"}]], "InlineFormula",
   ExpressionUUID->"2e926ae5-43ff-434c-a6c6-455019116750"],
- "\[LineSeparator]represents a plugin with multiple endpoints."
+ "\[LineSeparator]represents a plugin with multiple endpoints.\n",
+ Cell["   ", "ModInfo",ExpressionUUID->"21e23ed8-2d57-48b1-b745-10afd311424d"],
+ Cell[BoxData[
+  RowBox[{
+   RowBox[{
+    RowBox[{"ChatGPTPlugin", "[", 
+     RowBox[{
+      StyleBox["assoc", "TI"], ",", 
+      RowBox[{"\[LeftAssociation]", 
+       RowBox[{
+        RowBox[{
+        "\"\<\!\(\*SubscriptBox[StyleBox[\"name\", \"TI\"], StyleBox[\"1\", \
+\"TR\"]]\)\>\"", "\[Rule]", 
+         SubscriptBox[
+          StyleBox["endpointSpec", "TI"], 
+          StyleBox["1", "TR"]]}], ",", 
+        RowBox[{
+        "\"\<\!\(\*SubscriptBox[StyleBox[\"name\", \"TI\"], StyleBox[\"2\", \
+\"TR\"]]\)\>\"", "\[Rule]", 
+         SubscriptBox[
+          StyleBox["endpointSpec", "TI"], 
+          StyleBox["2", "TR"]]}]}]}]}]}], "|>"}], "]"}]], "InlineFormula",
+  ExpressionUUID->"1786acc3-fecb-425c-a38f-d280db2336be"],
+ "\[LineSeparator]represents a plugin with an association of endpoints.\n",
+ Cell["   ", "ModInfo",ExpressionUUID->"e808c7bf-4ec2-46f7-a264-60c51c2418db"],
+ Cell[BoxData[
+  RowBox[{"ChatGPTPlugin", "[", 
+   StyleBox["assoc", "TI"], "]"}]], "InlineFormula",ExpressionUUID->
+  "24725cb5-cc0f-49ce-b60b-da5e799a7b05"],
+ "\[LineSeparator]represents a plugin with an association containing endpoint \
+information."
 }], "Usage",
- CellChangeTimes->{{3.8894725284300337`*^9, 3.889472656670525*^9}},
+ CellChangeTimes->{{3.8894725284300337`*^9, 3.889472656670525*^9}, {
+  3.890399291381839*^9, 3.8903993142366333`*^9}, {3.890399402987155*^9, 
+  3.89039948230485*^9}},
  CellID->1018763738,ExpressionUUID->"12a193bc-e708-41a8-8f3e-7765e8826b51"],
 
 Cell[TextData[{
@@ -104,7 +136,49 @@ Cell[TextData[{
  " objects."
 }], "Notes",
  CellChangeTimes->{{3.889472934883615*^9, 3.889472962080657*^9}},
- CellID->1510575087,ExpressionUUID->"7dec71f9-5f8b-4b1a-8d44-15a135effb64"]
+ CellID->1510575087,ExpressionUUID->"7dec71f9-5f8b-4b1a-8d44-15a135effb64"],
+
+Cell[TextData[{
+ "If the endpoints are given as an association, ",
+ Cell[BoxData[
+  RowBox[{
+   ButtonBox["ChatGPTPluginEndpoint",
+    BaseStyle->"Link",
+    ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginEndpoint"], 
+   "[", 
+   RowBox[{
+   "\"\<\!\(\*SubscriptBox[StyleBox[\"name\", \"TI\"], StyleBox[\"i\", \
+\"TI\"]]\)\>\"", ",", 
+    SubscriptBox[
+     StyleBox["endpointSpec", "TI"], 
+     StyleBox["i", "TI"]]}], "]"}]], "InlineFormula",ExpressionUUID->
+  "dd8a625b-980a-4315-b726-be9767fd29a5"],
+ " is used to convert them to ",
+ Cell[BoxData[
+  ButtonBox["ChatGPTPluginEndpoint",
+   BaseStyle->"Link",
+   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPluginEndpoint"]], 
+  "InlineFormula",ExpressionUUID->"9fdc5029-4b5e-4563-acf2-93ac469c519c"],
+ " objects."
+}], "Notes",
+ CellChangeTimes->{{3.89039954064985*^9, 3.890399585082942*^9}, {
+  3.890399648797999*^9, 3.8903996697236853`*^9}},
+ CellID->148526490,ExpressionUUID->"f70fe9e1-cf4f-4c5b-9f33-4d2078ae8597"],
+
+Cell[TextData[{
+ "In the single argument form, ",
+ Cell[BoxData[
+  StyleBox["assoc", "TI"]], "InlineFormula",ExpressionUUID->
+  "a1101303-2429-4e30-9dcb-f6e4db329ff1"],
+ " must contain the key ",
+ Cell[BoxData[
+ "\"\<Endpoints\>\""], "InlineFormula",ExpressionUUID->
+  "190dcf1a-57fb-4cc9-aa12-fd0d023f272d"],
+ " associated with a value of the form supported by the second argument."
+}], "Notes",
+ CellChangeTimes->{{3.890399317242186*^9, 3.890399359396554*^9}, {
+  3.890399497478211*^9, 3.890399523878579*^9}},
+ CellID->504065141,ExpressionUUID->"bdbab817-eefd-45c3-a8ca-9272349cc403"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -147,10 +221,10 @@ Cell[TextData[{
     "90c1c032-eb97-4bb3-889e-8f7b59467ad9"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "d52b66ce-af3b-453e-b4f9-c7b3d7d02b72", 
-     "7cdbd34a-53fb-4aa5-8434-c1ca7f9bc17d"], $CellContext`cellobj$$ = 
+     "e67ed17b-603e-4b72-8d47-4753fbb95b87"], $CellContext`cellobj$$ = 
     CellObject[
     "7caccf6f-98b7-40f0-84e5-0ea889fb23b1", 
-     "b594dd37-562e-4197-ad97-6390ca0f53e6"]}, 
+     "3f3ebaf1-b313-4b0f-8c94-10f4e5df7a3d"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -272,31 +346,34 @@ Cell[BoxData[
 
 Cell["Create a ChatGPT plugin:", "ExampleText",
  CellChangeTimes->{{3.889473009228105*^9, 3.889473020802627*^9}},
- CellID->374440937,ExpressionUUID->"82f36a2c-5794-41e3-8ac6-e35939435eaa"],
+ CellID->1353473655,ExpressionUUID->"ab6e110b-af4a-44f4-98cb-d54fc1d6551d"],
 
 Cell[CellGroupData[{
 
 Cell[BoxData[
  RowBox[{"plugin", "=", 
   RowBox[{"ChatGPTPlugin", "[", 
-   RowBox[{
-    RowBox[{"<|", "\[IndentingNewLine]", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{
+     RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
+     "\[IndentingNewLine]", 
      RowBox[{
-      RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{
-      "\"\<Description\>\"", "->", 
-       "\"\<Get the populations of cities.\>\""}]}], "\[IndentingNewLine]", 
-     "|>"}], ",", "\[IndentingNewLine]", 
-    RowBox[{"ChatGPTPluginEndpoint", "[", 
-     RowBox[{"\"\<getCityPopulation\>\"", ",", 
-      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
-      RowBox[{
-       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
+     "\"\<Description\>\"", "->", "\"\<Get the populations of cities.\>\""}], 
+     ",", "\[IndentingNewLine]", 
+     RowBox[{"\"\<Endpoints\>\"", "->", 
+      RowBox[{"<|", 
+       RowBox[{"\"\<getCityPopulation\>\"", "->", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+          RowBox[{
+           RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], 
+         "]"}]}], "|>"}]}]}], "\[IndentingNewLine]", "|>"}], 
    "\[IndentingNewLine]", "]"}]}]], "Input",
- CellChangeTimes->{{3.8894730240943127`*^9, 3.889473030319086*^9}},
- CellLabel->"In[2]:=",
- CellID->428262334,ExpressionUUID->"d1ac4692-934e-4955-bdca-859df5fca75b"],
+ CellChangeTimes->{{3.8894730240943127`*^9, 3.889473030319086*^9}, {
+   3.890399596184895*^9, 3.890399612801609*^9}, 3.890399677550045*^9},
+ CellLabel->"In[1]:=",
+ CellID->1684930561,ExpressionUUID->"09d200e4-3687-43d5-bbff-0c4e6b70706e"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -445,13 +522,15 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                     
-                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{
-                    "getCityPopulation", 
-                    Missing["NotSpecified"]}, {
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "getCityPopulation", "Prompt" -> 
+                    Missing["NotSpecified"], 
+                    "Parameters" -> {
                     "city" -> <|
                     "Interpreter" -> "City", "Help" -> 
-                    Missing["NotSpecified"], "Required" -> True|>}, Slot[
-                    "city"]["Population"]& , {}], Selectable -> False, 
+                    Missing["NotSpecified"], "Required" -> True|>}, 
+                    "Function" -> (Slot["city"]["Population"]& ), 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
                     Editable -> False, SelectWithContents -> True]}}, 
                     GridBoxAlignment -> {"Columns" -> {{Left}}}, 
                     DefaultBaseStyle -> "Column", 
@@ -480,25 +559,29 @@ Cell[BoxData[
     DynamicModuleValues:>{}], "]"}],
   Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
    "Name" -> "CityPopulationFinder", "Description" -> 
-    "Get the populations of cities.", "Prompt" -> ""|>, {
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{"getCityPopulation", 
-      Missing["NotSpecified"]}, {
-     "city" -> <|
-       "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], "Required" -> 
-        True|>}, Slot["city"]["Population"]& , {}]}, {}],
+    "Get the populations of cities.", "Prompt" -> "", "Endpoints" -> {
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "getCityPopulation", "Prompt" -> 
+        Missing["NotSpecified"], 
+        "Parameters" -> {
+         "city" -> <|
+           "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>}, 
+        "Function" -> (Slot["city"]["Population"]& ), 
+        "APIFunctionOptions" -> {}|>, {}]}|>, {}],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
  CellChangeTimes->{{3.889473027310793*^9, 3.8894730306369877`*^9}, 
-   3.890324358348649*^9},
- CellLabel->"Out[2]=",
- CellID->1213392519,ExpressionUUID->"58305a5c-df76-498b-a9df-85e8aad1f614"]
+   3.890324358348649*^9, 3.890399613272441*^9},
+ CellLabel->"Out[1]=",
+ CellID->479805445,ExpressionUUID->"ac95fa3c-cc21-4abe-9673-cca76bb3860f"]
 }, Open  ]],
 
 Cell["Deploy it to a local web server:", "ExampleText",
  CellChangeTimes->{{3.8894730321254272`*^9, 3.8894730348172617`*^9}, {
   3.889473077023293*^9, 3.889473079403915*^9}},
- CellID->1506863819,ExpressionUUID->"c4ba3a55-3ba9-4677-abcc-4c30679d17c3"],
+ CellID->1908569385,ExpressionUUID->"166cffe6-403c-4bb4-a351-d559e8542a5d"],
 
 Cell[CellGroupData[{
 
@@ -507,7 +590,7 @@ Cell[BoxData[
   RowBox[{"ChatGPTPluginDeploy", "[", "plugin", "]"}]}]], "Input",
  CellChangeTimes->{{3.8894730366694183`*^9, 3.889473040448915*^9}},
  CellLabel->"In[3]:=",
- CellID->288831357,ExpressionUUID->"d9e08b35-e949-4eb3-905e-0e9de2380e53"],
+ CellID->362418456,ExpressionUUID->"960f15e4-6980-4a54-9a91-01f080c7b3dd"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -1258,18 +1341,255 @@ Cell[BoxData[
   Selectable->False]], "Output",
  CellChangeTimes->{3.889473040788374*^9, 3.890324359878705*^9},
  CellLabel->"Out[3]=",
- CellID->1650544262,ExpressionUUID->"32766a7e-4677-43ab-9bca-4ab41f85cf39"]
+ CellID->903367100,ExpressionUUID->"47f00ae4-c2cc-4eb7-bd3c-849763bc024d"]
 }, Open  ]],
 
 Cell["Stop the web server:", "ExampleText",
  CellChangeTimes->{{3.889473069685279*^9, 3.889473074177333*^9}},
- CellID->1129729877,ExpressionUUID->"3f6e8677-f006-44eb-8d2d-45e9f048d044"],
+ CellID->181465410,ExpressionUUID->"85b2aa00-107d-4fbf-9506-009104b042ee"],
 
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  CellChangeTimes->{{3.889473081013341*^9, 3.889473083050357*^9}},
  CellLabel->"In[4]:=",
- CellID->1952056595,ExpressionUUID->"3ae9fa06-be04-4db8-8c28-00d0e72654f5"]
+ CellID->462367130,ExpressionUUID->"e910d36e-d74a-4011-8f61-722c80f328b7"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell[
+  "\t", "ExampleDelimiter",ExpressionUUID->
+   "a252dfcf-3543-4cef-b97e-f5d7b6120bbb"],
+  $Line = 0; Null]], "ExampleDelimiter",
+ CellID->774247027,ExpressionUUID->"64d98765-f079-432f-ac6a-78f3fc37c3e9"],
+
+Cell["Create a plugin with an explicit endpoint object::", "ExampleText",
+ CellChangeTimes->{{3.889473009228105*^9, 3.889473020802627*^9}, {
+  3.8903996934075327`*^9, 3.890399702059231*^9}},
+ CellID->374440937,ExpressionUUID->"82f36a2c-5794-41e3-8ac6-e35939435eaa"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"plugin", "=", 
+  RowBox[{"ChatGPTPlugin", "[", 
+   RowBox[{
+    RowBox[{"<|", "\[IndentingNewLine]", 
+     RowBox[{
+      RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
+      "\[IndentingNewLine]", 
+      RowBox[{
+      "\"\<Description\>\"", "->", "\"\<Get the populations of cities.\>\""}],
+       ",", "\[IndentingNewLine]", "\"\<Endpoints\>\""}], 
+     "\[IndentingNewLine]", "|>"}], ",", "\[IndentingNewLine]", 
+    RowBox[{"ChatGPTPluginEndpoint", "[", 
+     RowBox[{"\"\<getCityPopulation\>\"", ",", 
+      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+      RowBox[{
+       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
+   "\[IndentingNewLine]", "]"}]}]], "Input",
+ CellChangeTimes->{{3.8894730240943127`*^9, 3.889473030319086*^9}, {
+  3.890399596184895*^9, 3.890399612801609*^9}},
+ CellLabel->"In[2]:=",
+ CellID->428262334,ExpressionUUID->"d1ac4692-934e-4955-bdca-859df5fca75b"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPlugin",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"Get the populations of cities.\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"Get the populations of cities.\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   GridBox[{{
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                    "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{
+                    "getCityPopulation", 
+                    Missing["NotSpecified"]}, {
+                    "city" -> <|
+                    "Interpreter" -> "City", "Help" -> 
+                    Missing["NotSpecified"], "Required" -> True|>}, Slot[
+                    "city"]["Population"]& , {}], Selectable -> False, 
+                    Editable -> False, SelectWithContents -> True]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                   "Column"], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
+   "Name" -> "CityPopulationFinder", "Description" -> 
+    "Get the populations of cities.", "Prompt" -> ""|>, {
+    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{"getCityPopulation", 
+      Missing["NotSpecified"]}, {
+     "city" -> <|
+       "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], "Required" -> 
+        True|>}, Slot["city"]["Population"]& , {}]}, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{{3.889473027310793*^9, 3.8894730306369877`*^9}, 
+   3.890324358348649*^9},
+ CellLabel->"Out[2]=",
+ CellID->1213392519,ExpressionUUID->"58305a5c-df76-498b-a9df-85e8aad1f614"]
+}, Open  ]]
+}, Open  ]]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -1459,7 +1779,7 @@ TaggingRules->{
     "$UseNewPageDialog" -> ""}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "Wolfram/ChatGPTPluginKit"},
-FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
+FrontEndVersion->"13.3 for Mac OS X x86 (64-bit) (April 8, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"d52b66ce-af3b-453e-b4f9-c7b3d7d02b72"
@@ -1470,14 +1790,14 @@ ExpressionUUID->"d52b66ce-af3b-453e-b4f9-c7b3d7d02b72"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[60047, 1276, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"2b0a73e6-e7e1-4f1f-886a-7b783ec1c368",
+  Cell[74767, 1596, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"2b0a73e6-e7e1-4f1f-886a-7b783ec1c368",
    CellTags->"ExtendedExamples",
    CellID->330491882]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 66746, 1471}
+ {"ExtendedExamples", 81462, 1791}
  }
 *)
 (*NotebookFileOutline
@@ -1485,137 +1805,151 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 110, 1, 74, "ObjectName",ExpressionUUID->"af4293b2-0c4a-4da2-8a3c-795156d71e9a",
  CellID->722873431],
-Cell[693, 25, 1130, 27, 125, "Usage",ExpressionUUID->"12a193bc-e708-41a8-8f3e-7765e8826b51",
+Cell[693, 25, 2453, 59, 209, "Usage",ExpressionUUID->"12a193bc-e708-41a8-8f3e-7765e8826b51",
  CellID->1018763738],
-Cell[1826, 54, 394, 8, 27, "Notes",ExpressionUUID->"eadb8e92-9089-4b33-9c2a-a0c9a80445ea",
+Cell[3149, 86, 394, 8, 27, "Notes",ExpressionUUID->"eadb8e92-9089-4b33-9c2a-a0c9a80445ea",
  CellID->475027035],
-Cell[2223, 64, 325, 8, 27, "Notes",ExpressionUUID->"e33195e4-4d8b-40ef-93b1-e79937c04027",
+Cell[3546, 96, 325, 8, 27, "Notes",ExpressionUUID->"e33195e4-4d8b-40ef-93b1-e79937c04027",
  CellID->2094681816],
-Cell[2551, 74, 862, 15, 61, "2ColumnTableMod",ExpressionUUID->"7e7358b2-f09f-4efd-9bfa-3f34f18cbf47",
+Cell[3874, 106, 862, 15, 61, "2ColumnTableMod",ExpressionUUID->"7e7358b2-f09f-4efd-9bfa-3f34f18cbf47",
  CellID->1447720471],
-Cell[3416, 91, 596, 15, 29, "Notes",ExpressionUUID->"7dec71f9-5f8b-4b1a-8d44-15a135effb64",
- CellID->1510575087]
+Cell[4739, 123, 596, 15, 29, "Notes",ExpressionUUID->"7dec71f9-5f8b-4b1a-8d44-15a135effb64",
+ CellID->1510575087],
+Cell[5338, 140, 996, 25, 47, "Notes",ExpressionUUID->"f70fe9e1-cf4f-4c5b-9f33-4d2078ae8597",
+ CellID->148526490],
+Cell[6337, 167, 586, 13, 45, "Notes",ExpressionUUID->"bdbab817-eefd-45c3-a8ca-9272349cc403",
+ CellID->504065141]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[4049, 111, 459, 13, 34, "SeeAlsoSection",ExpressionUUID->"535e72e4-7dc0-4d07-9cae-c48b80739671",
+Cell[6960, 185, 459, 13, 40, "SeeAlsoSection",ExpressionUUID->"535e72e4-7dc0-4d07-9cae-c48b80739671",
  CellID->1582661346],
-Cell[4511, 126, 2132, 52, 23, "SeeAlso",ExpressionUUID->"e1c6eb6c-efbf-42b2-aa7d-953ad1cf4ac1",
+Cell[7422, 200, 2132, 52, 23, "SeeAlso",ExpressionUUID->"e1c6eb6c-efbf-42b2-aa7d-953ad1cf4ac1",
  CellID->1056790480]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[6680, 183, 436, 12, 47, "TechNotesSection",ExpressionUUID->"3e2d0df8-1b35-4c2a-b838-31b662d28d4d",
+Cell[9591, 257, 436, 12, 41, "TechNotesSection",ExpressionUUID->"3e2d0df8-1b35-4c2a-b838-31b662d28d4d",
  CellID->1787836670],
-Cell[7119, 197, 100, 1, 19, "Tutorials",ExpressionUUID->"15b6049d-8312-4e31-bc0e-6ab1637f8913",
+Cell[10030, 271, 100, 1, 19, "Tutorials",ExpressionUUID->"15b6049d-8312-4e31-bc0e-6ab1637f8913",
  CellID->579723866]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7256, 203, 117, 1, 34, "MoreAboutSection",ExpressionUUID->"388e79f8-c671-411f-990a-3333bcc43f37",
+Cell[10167, 277, 117, 1, 40, "MoreAboutSection",ExpressionUUID->"388e79f8-c671-411f-990a-3333bcc43f37",
  CellID->285709423],
-Cell[7376, 206, 100, 1, 19, "MoreAbout",ExpressionUUID->"29fc81e0-f0e8-4ad8-aab9-4a7a4bbc3551",
+Cell[10287, 280, 100, 1, 19, "MoreAbout",ExpressionUUID->"29fc81e0-f0e8-4ad8-aab9-4a7a4bbc3551",
  CellID->144837669]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7513, 212, 473, 13, 34, "RelatedLinksSection",ExpressionUUID->"de188d9b-d6ff-4965-96f2-b7dce232597d",
+Cell[10424, 286, 473, 13, 40, "RelatedLinksSection",ExpressionUUID->"de188d9b-d6ff-4965-96f2-b7dce232597d",
  CellID->1187730832],
-Cell[7989, 227, 104, 1, 19, "RelatedLinks",ExpressionUUID->"f0a4aedc-1e86-474d-bef9-86cbdfb4dc03",
+Cell[10900, 301, 104, 1, 19, "RelatedLinks",ExpressionUUID->"f0a4aedc-1e86-474d-bef9-86cbdfb4dc03",
  CellID->1331594559]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[8130, 233, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"092a9791-4f0a-47f1-bf05-c70b885f7fbd",
+Cell[11041, 307, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"092a9791-4f0a-47f1-bf05-c70b885f7fbd",
  CellID->1182667726],
-Cell[8664, 249, 251, 4, 47, "ExampleInitialization",ExpressionUUID->"e475ee33-baf0-4eb3-88ed-831eb8835b1c",
+Cell[11575, 323, 251, 4, 47, "ExampleInitialization",ExpressionUUID->"e475ee33-baf0-4eb3-88ed-831eb8835b1c",
  CellID->2135317897]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[8952, 258, 443, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"2c308301-29e3-465a-99a7-5df2a765a359",
+Cell[11863, 332, 443, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"2c308301-29e3-465a-99a7-5df2a765a359",
  CellID->1688669862],
-Cell[9398, 272, 188, 2, 24, "ExampleText",ExpressionUUID->"82f36a2c-5794-41e3-8ac6-e35939435eaa",
+Cell[12309, 346, 189, 2, 24, "ExampleText",ExpressionUUID->"ab6e110b-af4a-44f4-98cb-d54fc1d6551d",
+ CellID->1353473655],
+Cell[CellGroupData[{
+Cell[12523, 352, 1025, 23, 142, "Input",ExpressionUUID->"09d200e4-3687-43d5-bbff-0c4e6b70706e",
+ CellID->1684930561],
+Cell[13551, 377, 10102, 200, 53, "Output",ExpressionUUID->"ac95fa3c-cc21-4abe-9673-cca76bb3860f",
+ CellID->479805445]
+}, Open  ]],
+Cell[23668, 580, 250, 3, 24, "ExampleText",ExpressionUUID->"166cffe6-403c-4bb4-a351-d559e8542a5d",
+ CellID->1908569385],
+Cell[CellGroupData[{
+Cell[23943, 587, 271, 5, 27, "Input",ExpressionUUID->"960f15e4-6980-4a54-9a91-01f080c7b3dd",
+ CellID->362418456],
+Cell[24217, 594, 38733, 749, 53, "Output",ExpressionUUID->"47f00ae4-c2cc-4eb7-bd3c-849763bc024d",
+ CellID->903367100]
+}, Open  ]],
+Cell[62965, 1346, 184, 2, 24, "ExampleText",ExpressionUUID->"85b2aa00-107d-4fbf-9506-009104b042ee",
+ CellID->181465410],
+Cell[63152, 1350, 234, 4, 27, "Input",ExpressionUUID->"e910d36e-d74a-4011-8f61-722c80f328b7",
+ CellID->462367130],
+Cell[CellGroupData[{
+Cell[63411, 1358, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"64d98765-f079-432f-ac6a-78f3fc37c3e9",
+ CellID->774247027],
+Cell[63656, 1365, 265, 3, 24, "ExampleText",ExpressionUUID->"82f36a2c-5794-41e3-8ac6-e35939435eaa",
  CellID->374440937],
 Cell[CellGroupData[{
-Cell[9611, 278, 869, 20, 142, "Input",ExpressionUUID->"d1ac4692-934e-4955-bdca-859df5fca75b",
+Cell[63946, 1372, 966, 21, 161, "Input",ExpressionUUID->"d1ac4692-934e-4955-bdca-859df5fca75b",
  CellID->428262334],
-Cell[10483, 300, 9791, 194, 53, "Output",ExpressionUUID->"58305a5c-df76-498b-a9df-85e8aad1f614",
+Cell[64915, 1395, 9791, 194, 53, "Output",ExpressionUUID->"58305a5c-df76-498b-a9df-85e8aad1f614",
  CellID->1213392519]
-}, Open  ]],
-Cell[20289, 497, 250, 3, 24, "ExampleText",ExpressionUUID->"c4ba3a55-3ba9-4677-abcc-4c30679d17c3",
- CellID->1506863819],
-Cell[CellGroupData[{
-Cell[20564, 504, 271, 5, 27, "Input",ExpressionUUID->"d9e08b35-e949-4eb3-905e-0e9de2380e53",
- CellID->288831357],
-Cell[20838, 511, 38734, 749, 53, "Output",ExpressionUUID->"32766a7e-4677-43ab-9bca-4ab41f85cf39",
- CellID->1650544262]
-}, Open  ]],
-Cell[59587, 1263, 185, 2, 24, "ExampleText",ExpressionUUID->"3f6e8677-f006-44eb-8d2d-45e9f048d044",
- CellID->1129729877],
-Cell[59775, 1267, 235, 4, 27, "Input",ExpressionUUID->"3ae9fa06-be04-4db8-8c28-00d0e72654f5",
- CellID->1952056595]
+}, Open  ]]
+}, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[60047, 1276, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"2b0a73e6-e7e1-4f1f-886a-7b783ec1c368",
+Cell[74767, 1596, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"2b0a73e6-e7e1-4f1f-886a-7b783ec1c368",
  CellTags->"ExtendedExamples",
  CellID->330491882],
-Cell[60537, 1291, 242, 5, 35, "ExampleSection",ExpressionUUID->"a6596816-4e65-49f9-a567-0f3bec281820",
+Cell[75257, 1611, 242, 5, 35, "ExampleSection",ExpressionUUID->"a6596816-4e65-49f9-a567-0f3bec281820",
  CellID->1184349632],
-Cell[60782, 1298, 264, 5, 23, "ExampleSection",ExpressionUUID->"6a1d3ae0-f9df-49c8-8eb5-8e63d93f8206",
+Cell[75502, 1618, 264, 5, 23, "ExampleSection",ExpressionUUID->"6a1d3ae0-f9df-49c8-8eb5-8e63d93f8206",
  CellID->338340981],
 Cell[CellGroupData[{
-Cell[61071, 1307, 244, 5, 23, "ExampleSection",ExpressionUUID->"57b2e7f2-0377-44f4-a107-c50d03d7aecb",
+Cell[75791, 1627, 244, 5, 23, "ExampleSection",ExpressionUUID->"57b2e7f2-0377-44f4-a107-c50d03d7aecb",
  CellID->2107654058],
-Cell[61318, 1314, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"b21c48e0-861a-4a16-b48f-e83de99f2d3e",
+Cell[76038, 1634, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"b21c48e0-861a-4a16-b48f-e83de99f2d3e",
  CellID->598995541],
-Cell[61567, 1321, 247, 5, 22, "ExampleSubsection",ExpressionUUID->"78365e5e-b142-42ac-8ab3-b7f9d317a088",
+Cell[76287, 1641, 247, 5, 22, "ExampleSubsection",ExpressionUUID->"78365e5e-b142-42ac-8ab3-b7f9d317a088",
  CellID->2062204098]
 }, Open  ]],
-Cell[61829, 1329, 249, 5, 35, "ExampleSection",ExpressionUUID->"e8cf9d28-000d-4fec-8c81-76985e860942",
+Cell[76549, 1649, 249, 5, 35, "ExampleSection",ExpressionUUID->"e8cf9d28-000d-4fec-8c81-76985e860942",
  CellID->1225696153],
-Cell[62081, 1336, 259, 5, 23, "ExampleSection",ExpressionUUID->"8583e43f-6be9-4ab0-8b9e-e959e9765539",
+Cell[76801, 1656, 259, 5, 23, "ExampleSection",ExpressionUUID->"8583e43f-6be9-4ab0-8b9e-e959e9765539",
  CellID->1612101447],
-Cell[62343, 1343, 252, 5, 23, "ExampleSection",ExpressionUUID->"311331d0-7c72-4605-8af1-d84b0606c320",
+Cell[77063, 1663, 252, 5, 23, "ExampleSection",ExpressionUUID->"311331d0-7c72-4605-8af1-d84b0606c320",
  CellID->1935329177],
-Cell[62598, 1350, 257, 5, 23, "ExampleSection",ExpressionUUID->"ab6ced70-f21c-47d7-aaea-83269102dfde",
+Cell[77318, 1670, 257, 5, 23, "ExampleSection",ExpressionUUID->"ab6ced70-f21c-47d7-aaea-83269102dfde",
  CellID->1290160377],
-Cell[62858, 1357, 249, 5, 23, "ExampleSection",ExpressionUUID->"d7223d91-1a90-48c3-8d29-1e1e76302730",
+Cell[77578, 1677, 249, 5, 23, "ExampleSection",ExpressionUUID->"d7223d91-1a90-48c3-8d29-1e1e76302730",
  CellID->583072480]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[63144, 1367, 110, 1, 72, "MetadataSection",ExpressionUUID->"1d61fc84-a785-4b81-878b-477625ae5c85",
+Cell[77864, 1687, 110, 1, 72, "MetadataSection",ExpressionUUID->"1d61fc84-a785-4b81-878b-477625ae5c85",
  CellID->731290099],
-Cell[63257, 1370, 476, 12, 26, "History",ExpressionUUID->"b8124440-ee48-4f64-9109-c91a31cc646c",
+Cell[77977, 1690, 476, 12, 26, "History",ExpressionUUID->"b8124440-ee48-4f64-9109-c91a31cc646c",
  CellID->743782112],
 Cell[CellGroupData[{
-Cell[63758, 1386, 484, 13, 21, "CategorizationSection",ExpressionUUID->"b3085543-b2b6-45a7-8f15-fc64b3661cd0",
+Cell[78478, 1706, 484, 13, 21, "CategorizationSection",ExpressionUUID->"b3085543-b2b6-45a7-8f15-fc64b3661cd0",
  CellID->243647197],
-Cell[64245, 1401, 135, 2, 35, "Categorization",ExpressionUUID->"836e6b75-500d-4f27-a909-19cf0843511b",
+Cell[78965, 1721, 135, 2, 35, "Categorization",ExpressionUUID->"836e6b75-500d-4f27-a909-19cf0843511b",
  CellID->1874608797],
-Cell[64383, 1405, 152, 2, 35, "Categorization",ExpressionUUID->"166977d3-b367-4972-963b-31c2d9ff8176",
+Cell[79103, 1725, 152, 2, 35, "Categorization",ExpressionUUID->"166977d3-b367-4972-963b-31c2d9ff8176",
  CellID->817466042],
-Cell[64538, 1409, 150, 2, 35, "Categorization",ExpressionUUID->"cb2d61e2-1b99-4e47-a812-1afb3dce8c9b",
+Cell[79258, 1729, 150, 2, 35, "Categorization",ExpressionUUID->"cb2d61e2-1b99-4e47-a812-1afb3dce8c9b",
  CellID->1698878035],
-Cell[64691, 1413, 162, 2, 35, "Categorization",ExpressionUUID->"259c8d8f-823e-4636-ae68-71fb318f43ca",
+Cell[79411, 1733, 162, 2, 35, "Categorization",ExpressionUUID->"259c8d8f-823e-4636-ae68-71fb318f43ca",
  CellID->100563733]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[64890, 1420, 110, 1, 31, "KeywordsSection",ExpressionUUID->"f74de9bc-1fed-4015-b4d5-bfa06e925d1c",
+Cell[79610, 1740, 110, 1, 31, "KeywordsSection",ExpressionUUID->"f74de9bc-1fed-4015-b4d5-bfa06e925d1c",
  CellID->105030342],
-Cell[65003, 1423, 98, 1, 70, "Keywords",ExpressionUUID->"7eb7329a-533e-4cc0-8f72-5a6250db14d5",
+Cell[79723, 1743, 98, 1, 70, "Keywords",ExpressionUUID->"7eb7329a-533e-4cc0-8f72-5a6250db14d5",
  CellID->13400160]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[65138, 1429, 120, 1, 21, "TemplatesSection",ExpressionUUID->"632e439c-d6ba-4c33-8c37-af5143b4c4b7",
+Cell[79858, 1749, 120, 1, 21, "TemplatesSection",ExpressionUUID->"632e439c-d6ba-4c33-8c37-af5143b4c4b7",
  CellID->1878189832],
-Cell[65261, 1432, 148, 2, 70, "Template",ExpressionUUID->"252f24a9-d441-40dd-b411-8ae4d3a18ed9",
+Cell[79981, 1752, 148, 2, 70, "Template",ExpressionUUID->"252f24a9-d441-40dd-b411-8ae4d3a18ed9",
  CellID->874379171],
-Cell[65412, 1436, 137, 2, 70, "Template",ExpressionUUID->"31ea399e-96ac-4d33-b265-bb6a97a51767",
+Cell[80132, 1756, 137, 2, 70, "Template",ExpressionUUID->"31ea399e-96ac-4d33-b265-bb6a97a51767",
  CellID->460130576],
-Cell[65552, 1440, 135, 2, 70, "Template",ExpressionUUID->"32e4ef4d-1512-4b74-8a53-caaa5eab4e31",
+Cell[80272, 1760, 135, 2, 70, "Template",ExpressionUUID->"32e4ef4d-1512-4b74-8a53-caaa5eab4e31",
  CellID->325977985],
-Cell[65690, 1444, 137, 2, 70, "Template",ExpressionUUID->"c7c44a29-819b-4dc6-aa94-3eaaf6abbc62",
+Cell[80410, 1764, 137, 2, 70, "Template",ExpressionUUID->"c7c44a29-819b-4dc6-aa94-3eaaf6abbc62",
  CellID->481210398]
 }, Closed]]
 }, Open  ]]
 }
 ]
 *)
-
-(* End of internal cache information *)
 

--- a/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPluginDeploy.nb
+++ b/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPluginDeploy.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    709311,      12805]
-NotebookOptionsPosition[    696067,      12536]
-NotebookOutlinePosition[    697235,      12569]
-CellTagsIndexPosition[    697153,      12564]
+NotebookDataLength[    699973,      12615]
+NotebookOptionsPosition[    687000,      12352]
+NotebookOutlinePosition[    688164,      12385]
+CellTagsIndexPosition[    688082,      12380]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -29,7 +29,8 @@ Cell[TextData[{
   RowBox[{"ChatGPTPluginDeploy", "[", 
    StyleBox["plugin", "TI"], "]"}]], "InlineFormula",ExpressionUUID->
   "e94ddb87-eed1-42a8-b48e-2f482ef1d064"],
- " \[LineSeparator]deploys a ChatGPT plugin to a local web server.\n",
+ " \[LineSeparator]deploys a ChatGPT plugin specification to a local web \
+server.\n",
  Cell["   ", "ModInfo",ExpressionUUID->"b9d72727-a16b-4ce6-bdd0-132fdf4c3584"],
  Cell[BoxData[
   RowBox[{"ChatGPTPluginDeploy", "[", 
@@ -39,7 +40,8 @@ Cell[TextData[{
   "b1091627-ceca-470d-b382-8c70cd69442c"],
  "\[LineSeparator]sets up the web server to use the specified port number."
 }], "Usage",
- CellChangeTimes->{{3.889473129939982*^9, 3.889473165913517*^9}},
+ CellChangeTimes->{{3.889473129939982*^9, 3.889473165913517*^9}, {
+  3.890398875679706*^9, 3.890398877501683*^9}},
  CellID->2092392664,ExpressionUUID->"28e7573e-710b-4465-8242-4a06f5ae31e8"],
 
 Cell[TextData[{
@@ -85,9 +87,16 @@ Cell[TextData[{
    BaseStyle->"Link",
    ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPlugin"]], 
   "InlineFormula",ExpressionUUID->"18e82487-c088-49e6-a4d6-266cc70c6ac9"],
- " object."
+ " object, or an association that specifies a valid ",
+ Cell[BoxData[
+  ButtonBox["ChatGPTPlugin",
+   BaseStyle->"Link",
+   ButtonData->"paclet:Wolfram/ChatGPTPluginKit/ref/ChatGPTPlugin"]], 
+  "InlineFormula",ExpressionUUID->"7b9a7ee1-9df9-4e82-9769-5a0af9ca4bfd"],
+ "."
 }], "Notes",
- CellChangeTimes->{{3.8894732911277847`*^9, 3.889473305332693*^9}},
+ CellChangeTimes->{{3.8894732911277847`*^9, 3.889473305332693*^9}, {
+  3.890398696616632*^9, 3.890398720878022*^9}},
  CellID->1735908722,ExpressionUUID->"7f69d1f7-9102-4e84-8a1f-07341c4c055e"],
 
 Cell[TextData[{
@@ -217,10 +226,10 @@ Cell[TextData[{
     "4791a388-5c13-467a-b375-f25dfb0348d5"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "02af9b38-5847-4462-9a83-6598f90ff537", 
-     "115e9168-e5b9-4034-bb88-c29d8c3cbea8"], $CellContext`cellobj$$ = 
+     "b3c388c6-dd14-44de-9ef2-7ee9c7659cbf"], $CellContext`cellobj$$ = 
     CellObject[
     "bf0bcbb6-d1c5-4bea-9d70-6fe36249723d", 
-     "3694b68b-4ee3-4cc6-8487-4686d46a592d"]}, 
+     "25447802-006c-43e2-9f10-9f211f8c345d"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -340,244 +349,35 @@ Cell[BoxData[
   $Line = 0; Null]], "PrimaryExamplesSection",
  CellID->1023238678,ExpressionUUID->"b4b63811-622c-4c97-bb9f-fd0fcbfaacf8"],
 
-Cell["Create a ChatGPT plugin:", "ExampleText",
- CellChangeTimes->{{3.889473009228105*^9, 3.889473020802627*^9}},
+Cell["Deploy a ChatGPT plugin to a local web server:", "ExampleText",
+ CellChangeTimes->{{3.889473009228105*^9, 3.889473020802627*^9}, {
+  3.890398799300242*^9, 3.8903988109837*^9}},
  CellID->374440937,ExpressionUUID->"ddde5435-aacf-4099-b303-8660c4934633"],
 
 Cell[CellGroupData[{
 
 Cell[BoxData[
- RowBox[{"plugin", "=", 
-  RowBox[{"ChatGPTPlugin", "[", 
-   RowBox[{
-    RowBox[{"<|", "\[IndentingNewLine]", 
-     RowBox[{
-      RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{
-      "\"\<Description\>\"", "->", 
-       "\"\<Get the populations of cities.\>\""}]}], "\[IndentingNewLine]", 
-     "|>"}], ",", "\[IndentingNewLine]", 
-    RowBox[{"ChatGPTPluginEndpoint", "[", 
-     RowBox[{"\"\<getCityPopulation\>\"", ",", 
-      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
-      RowBox[{
-       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
-   "\[IndentingNewLine]", "]"}]}]], "Input",
- CellChangeTimes->{{3.8894730240943127`*^9, 3.889473030319086*^9}},
- CellLabel->"In[2]:=",
- CellID->428262334,ExpressionUUID->"4c0ee421-71dc-4cfe-989d-3f35108998f4"],
-
-Cell[BoxData[
- InterpretationBox[
-  RowBox[{
-   TagBox["ChatGPTPlugin",
-    "SummaryHead"], "[", 
-   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-    
-    TemplateBox[{
-      PaneSelectorBox[{False -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  TagBox[
-                   GridBox[{{
-                    InterpretationBox[
-                    RowBox[{
-                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
-                    
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxOpener"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxCloser"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
-                    "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                    
-                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{
-                    "getCityPopulation", 
-                    Missing["NotSpecified"]}, {
-                    "city" -> <|
-                    "Interpreter" -> "City", "Help" -> 
-                    Missing["NotSpecified"], "Required" -> True|>}, Slot[
-                    "city"]["Population"]& , {}], Selectable -> False, 
-                    Editable -> False, SelectWithContents -> True]}}, 
-                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
-                    DefaultBaseStyle -> "Column", 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-                   "Column"], "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"\"", "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
-       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
-     "SummaryPanel"],
-    DynamicModuleValues:>{}], "]"}],
-  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
-   "Name" -> "CityPopulationFinder", "Description" -> 
-    "Get the populations of cities.", "Prompt" -> ""|>, {
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{"getCityPopulation", 
-      Missing["NotSpecified"]}, {
-     "city" -> <|
-       "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], "Required" -> 
-        True|>}, Slot["city"]["Population"]& , {}]}, {}],
-  Editable->False,
-  SelectWithContents->True,
-  Selectable->False]], "Output",
- CellChangeTimes->{{3.889473027310793*^9, 3.8894730306369877`*^9}, 
-   3.8903243280603333`*^9},
- CellLabel->"Out[2]=",
- CellID->1988828988,ExpressionUUID->"8324416d-f291-4a60-baa5-59170c58cb3f"]
-}, Open  ]],
-
-Cell["Deploy it to a local web server:", "ExampleText",
- CellChangeTimes->{{3.8894730321254272`*^9, 3.8894730348172617`*^9}, {
-  3.889473077023293*^9, 3.889473079403915*^9}},
- CellID->1506863819,ExpressionUUID->"267d0710-2c42-486d-b72f-785bd23d6312"],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
  RowBox[{"server", "=", 
-  RowBox[{"ChatGPTPluginDeploy", "[", "plugin", "]"}]}]], "Input",
- CellChangeTimes->{{3.8894730366694183`*^9, 3.889473040448915*^9}},
- CellLabel->"In[3]:=",
- CellID->288831357,ExpressionUUID->"3468591e-ff25-45d7-860f-a0fd3906ff53"],
+  RowBox[{"ChatGPTPluginDeploy", "[", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{
+     RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<Endpoints\>\"", "->", 
+      RowBox[{"<|", 
+       RowBox[{"\"\<getCityPopulation\>\"", "->", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+          RowBox[{
+           RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], 
+         "]"}]}], "|>"}]}]}], "\[IndentingNewLine]", "|>"}], "]"}]}]], "Input",\
+
+ CellChangeTimes->{{3.8894730240943127`*^9, 3.889473030319086*^9}, {
+  3.890398737336687*^9, 3.890398752365046*^9}, {3.890398801057192*^9, 
+  3.890398818379952*^9}},
+ CellLabel->"In[8]:=",
+ CellID->428262334,ExpressionUUID->"4c0ee421-71dc-4cfe-989d-3f35108998f4"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -591,10 +391,11 @@ Cell[BoxData[
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {10., {0., 10.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -772,14 +573,12 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, {ImageSize -> {Automatic, 
-                Dynamic[
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                  Magnification])]}, AspectRatio -> Automatic, 
-              ImagePadding -> {{0., 0.}, {0., 0.}}, 
-              ImageSize -> {64.43359375, 68.}, 
-              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
-              Automatic}], 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -797,7 +596,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640556234036835], {
+                    3610800521059676968], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -805,29 +604,32 @@ Cell[BoxData[
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
                     Blank[]] :> Missing["NotAvailable"]}], 
                     Missing["NotAvailable"]], StandardForm], 
+                   ImageSizeCache -> {103., {1.783203125, 7.47119140625}}, 
                    TrackedSymbols :> {
                     ZeroMQLink`PackageScope`$SocketListeners}], 
-                  "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
+                  "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
             PaneBox[
              ButtonBox[
               DynamicBox[
                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+              Appearance -> None, BaseStyle -> {}, 
+              ButtonFunction :> (Typeset`open$$ = False), Evaluator -> 
+              Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -1005,14 +807,12 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, {ImageSize -> {Automatic, 
-                Dynamic[
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                  Magnification])]}, AspectRatio -> Automatic, 
-              ImagePadding -> {{0., 0.}, {0., 0.}}, 
-              ImageSize -> {64.43359375, 68.}, 
-              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
-              Automatic}], 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -1030,7 +830,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640556234036835], {
+                    3610800521059676968], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -1169,7 +969,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-84f03f3d-2451-4c2b-9de7-fb52fef66a52\"", 
+                    "\"TCPSERVER-5323422e-f983-4c7a-8c22-d608a1a4decb\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -1245,7 +1045,6 @@ Cell[BoxData[
                     56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
                     31.675}}]}}]}, {
                     FilledCurveBox[{{
-                    
                     Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
                     56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
                     43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
@@ -1276,7 +1075,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-84f03f3d-2451-4c2b-9de7-fb52fef66a52\"", 
+                    "\"TCPSERVER-5323422e-f983-4c7a-8c22-d608a1a4decb\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -1303,32 +1102,33 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-84f03f3d-2451-4c2b-9de7-fb52fef66a52"], 
-                   Selectable -> False, Editable -> False, SelectWithContents -> 
-                   True], "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
+                   "TCPSERVER-5323422e-f983-4c7a-8c22-d608a1a4decb"], 
+                   Editable -> False, SelectWithContents -> True, Selectable -> 
+                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610640556234036835],
+  SocketListener[3610800521059676968],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
- CellChangeTimes->{3.889473040788374*^9, 3.890324329104805*^9},
- CellLabel->"Out[3]=",
- CellID->431645507,ExpressionUUID->"714978d2-e987-4f31-85ed-c2282ee244a4"]
+ CellChangeTimes->{{3.889473027310793*^9, 3.8894730306369877`*^9}, 
+   3.8903243280603333`*^9, {3.890398778190605*^9, 3.890398818646522*^9}},
+ CellLabel->"Out[8]=",
+ CellID->1461594601,ExpressionUUID->"a0e2e263-bf39-4602-a543-b483b6ae2107"]
 }, Open  ]],
 
 Cell["Stop the web server:", "ExampleText",
@@ -1338,7 +1138,7 @@ Cell["Stop the web server:", "ExampleText",
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  CellChangeTimes->{{3.889473081013341*^9, 3.889473083050357*^9}},
- CellLabel->"In[4]:=",
+ CellLabel->"In[9]:=",
  CellID->1952056595,ExpressionUUID->"3634bc9f-131f-45a0-8ce1-05b383133cf9"]
 }, Open  ]],
 
@@ -1384,22 +1184,22 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{"plugin", "=", 
   RowBox[{"ChatGPTPlugin", "[", 
-   RowBox[{
-    RowBox[{"<|", "\[IndentingNewLine]", 
-     RowBox[{
-      RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{
-      "\"\<Description\>\"", "->", 
-       "\"\<Get the populations of cities.\>\""}]}], "\[IndentingNewLine]", 
-     "|>"}], ",", "\[IndentingNewLine]", 
-    RowBox[{"ChatGPTPluginEndpoint", "[", 
-     RowBox[{"\"\<getCityPopulation\>\"", ",", 
-      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
-      RowBox[{
-       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{
+     RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<Endpoints\>\"", "->", 
+      RowBox[{"<|", 
+       RowBox[{"\"\<getCityPopulation\>\"", "->", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+          RowBox[{
+           RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], 
+         "]"}]}], "|>"}]}]}], "\[IndentingNewLine]", "|>"}], 
    "\[IndentingNewLine]", "]"}]}]], "Input",
- CellChangeTimes->{{3.889474308221489*^9, 3.8894743093761187`*^9}},
+ CellChangeTimes->{{3.889474308221489*^9, 3.8894743093761187`*^9}, {
+  3.8903988930805063`*^9, 3.890398897836549*^9}},
  CellLabel->"In[2]:=",
  CellID->1020351672,ExpressionUUID->"88260ee7-e80c-42e4-82c3-bb133e611cc6"],
 
@@ -1431,8 +1231,7 @@ Cell[BoxData[
                RowBox[{
                  TagBox["\"description: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}}, 
+                 TagBox["\"\"", "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
               "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
              False, GridBoxItemSize -> {
@@ -1465,8 +1264,7 @@ Cell[BoxData[
                RowBox[{
                  TagBox["\"description: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}, {
+                 TagBox["\"\"", "SummaryItem"]}]}, {
                RowBox[{
                  TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
@@ -1550,13 +1348,15 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                     
-                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{
-                    "getCityPopulation", 
-                    Missing["NotSpecified"]}, {
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "getCityPopulation", "Prompt" -> 
+                    Missing["NotSpecified"], 
+                    "Parameters" -> {
                     "city" -> <|
                     "Interpreter" -> "City", "Help" -> 
-                    Missing["NotSpecified"], "Required" -> True|>}, Slot[
-                    "city"]["Population"]& , {}], Selectable -> False, 
+                    Missing["NotSpecified"], "Required" -> True|>}, 
+                    "Function" -> (Slot["city"]["Population"]& ), 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
                     Editable -> False, SelectWithContents -> True]}}, 
                     GridBoxAlignment -> {"Columns" -> {{Left}}}, 
                     DefaultBaseStyle -> "Column", 
@@ -1584,19 +1384,24 @@ Cell[BoxData[
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
   Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
-   "Name" -> "CityPopulationFinder", "Description" -> 
-    "Get the populations of cities.", "Prompt" -> ""|>, {
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{"getCityPopulation", 
-      Missing["NotSpecified"]}, {
-     "city" -> <|
-       "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], "Required" -> 
-        True|>}, Slot["city"]["Population"]& , {}]}, {}],
+   "Name" -> "CityPopulationFinder", "Description" -> "", "Prompt" -> "", 
+    "Endpoints" -> {
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "getCityPopulation", "Prompt" -> 
+        Missing["NotSpecified"], 
+        "Parameters" -> {
+         "city" -> <|
+           "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>}, 
+        "Function" -> (Slot["city"]["Population"]& ), 
+        "APIFunctionOptions" -> {}|>, {}]}|>, {}],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
- CellChangeTimes->{3.8894743100007887`*^9, 3.890324335190215*^9},
+ CellChangeTimes->{3.8894743100007887`*^9, 3.890324335190215*^9, 
+  3.890398910780046*^9},
  CellLabel->"Out[2]=",
- CellID->1492314782,ExpressionUUID->"dc9dda80-d878-40f1-b0ad-738284d571da"]
+ CellID->1390859097,ExpressionUUID->"821731f1-f397-4061-a99d-0c24587a4188"]
 }, Open  ]],
 
 Cell["Deploy the web server:", "ExampleText",
@@ -5685,58 +5490,61 @@ Cell[BoxData[{
  RowBox[{"server", "=", 
   RowBox[{"ChatGPTPluginDeploy", "@", 
    RowBox[{"ChatGPTPlugin", "[", 
-    RowBox[{
-     RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{"<|", "\[IndentingNewLine]", 
+     RowBox[{
+      RowBox[{"\"\<Name\>\"", "->", "\"\<TODOList\>\""}], ",", 
+      "\[IndentingNewLine]", 
       RowBox[{
-       RowBox[{"\"\<Name\>\"", "->", "\"\<TODOList\>\""}], ",", 
-       "\[IndentingNewLine]", 
-       RowBox[{
-       "\"\<Prompt\>\"", "->", 
-        "\"\<Plugin for managing a TODO list, you can add, remove and view \
+      "\"\<Prompt\>\"", "->", 
+       "\"\<Plugin for managing a TODO list, you can add, remove and view \
 your TODOs.\>\""}], ",", "\[IndentingNewLine]", 
-       RowBox[{
-       "\"\<Description\>\"", "->", 
-        "\"\<Plugin for managing a TODO list, you can add, remove and view \
-your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",", 
-     "\[IndentingNewLine]", 
-     RowBox[{"{", "\[IndentingNewLine]", 
       RowBox[{
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<getTodos\>\"", ",", "\"\<username\>\"", ",", 
-         RowBox[{
-          RowBox[{"Lookup", "[", 
-           RowBox[{"todos", ",", "#username", ",", 
-            RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}], ",", 
-       "\[IndentingNewLine]", 
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<addTodo\>\"", ",", 
-         RowBox[{"{", 
-          RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
-         RowBox[{
-          RowBox[{"(", 
+      "\"\<Description\>\"", "->", 
+       "\"\<Plugin for managing a TODO list, you can add, remove and view \
+your TODOs.\>\""}], ",", "\[IndentingNewLine]", 
+      RowBox[{"\"\<Endpoints\>\"", "->", 
+       RowBox[{"<|", "\[IndentingNewLine]", 
+        RowBox[{
+         RowBox[{"\"\<getTodos\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
+           RowBox[{"\"\<username\>\"", ",", 
+            RowBox[{
+             RowBox[{"Lookup", "[", 
+              RowBox[{"todos", ",", "#username", ",", 
+               RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}]}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"\"\<addTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
            RowBox[{
-            RowBox[{"todos", "[", "#username", "]"}], "=", 
-            RowBox[{"Append", "[", 
-             RowBox[{
-              RowBox[{"Lookup", "[", 
-               RowBox[{"todos", ",", "#username", ",", 
-                RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], ")"}], 
-          "&"}]}], "]"}], ",", "\[IndentingNewLine]", 
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<deleteTodo\>\"", ",", 
-         RowBox[{"{", 
-          RowBox[{"\"\<username\>\"", ",", 
-           RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], 
-         ",", 
-         RowBox[{
-          RowBox[{"(", 
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
+            RowBox[{
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Append", "[", 
+                RowBox[{
+                 RowBox[{"Lookup", "[", 
+                  RowBox[{"todos", ",", "#username", ",", 
+                   RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], 
+              ")"}], "&"}]}], "]"}]}], ",", "\[IndentingNewLine]", 
+         RowBox[{"\"\<deleteTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
            RowBox[{
-            RowBox[{"todos", "[", "#username", "]"}], "=", 
-            RowBox[{"Delete", "[", 
-             RowBox[{
-              RowBox[{"todos", "[", "#username", "]"}], ",", 
-              RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], "&"}]}], 
-        "]"}]}], "\[IndentingNewLine]", "}"}]}], "\[IndentingNewLine]", 
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", 
+              RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], 
+            ",", 
+            RowBox[{
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Delete", "[", 
+                RowBox[{
+                 RowBox[{"todos", "[", "#username", "]"}], ",", 
+                 RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], 
+             "&"}]}], "]"}]}]}], "\[IndentingNewLine]", "|>"}]}]}], 
+     "\[IndentingNewLine]", "|>"}], "\[IndentingNewLine]", 
     "]"}]}]}]}], "Input",
  CellChangeTimes->{{3.8892965279564943`*^9, 3.889296531899847*^9}, {
    3.8892967426239843`*^9, 3.8892967723501663`*^9}, {3.8892968593944063`*^9, 
@@ -5746,7 +5554,7 @@ your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",",
    3.88941170940053*^9, 3.889411712451518*^9}, 3.889450158192483*^9, 
    3.8894503830116034`*^9, {3.889450484885947*^9, 3.889450491289304*^9}, {
    3.889454945124021*^9, 3.8894549453458643`*^9}, {3.889474478392243*^9, 
-   3.889474499492263*^9}},
+   3.889474499492263*^9}, {3.890398932592304*^9, 3.890398937697775*^9}},
  CellLabel->"In[1]:=",
  CellID->41348088,ExpressionUUID->"4da1c156-9ede-43e7-825f-4a813266e782"],
 
@@ -9782,30 +9590,37 @@ called:\
   3.889473808944811*^9, 3.889473824728115*^9}},
  CellID->287202388,ExpressionUUID->"1c0a2a09-3953-4129-8383-f50746993bd4"],
 
+Cell[BoxData[
+ RowBox[{"Needs", "[", "\"\<Wolfram`ChatGPTPluginKit`\>\"", "]"}]], "Input",
+ CellLabel->"In[1]:=",
+ CellID->1160191379,ExpressionUUID->"74a8e071-d4ff-4212-a1cd-9b1341f2e321"],
+
 Cell[CellGroupData[{
 
 Cell[BoxData[{
  RowBox[{
   RowBox[{"counter", "=", "0"}], ";"}], "\n", 
  RowBox[{"server", "=", 
-  RowBox[{"ChatGPTPluginDeploy", "@", 
-   RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"ChatGPTPluginDeploy", "[", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
     RowBox[{
-     RowBox[{"<|", "\[IndentingNewLine]", 
-      RowBox[{
-       RowBox[{"\"\<Name\>\"", "->", "\"\<Counter\>\""}], ",", 
-       "\[IndentingNewLine]", 
-       RowBox[{"\"\<Description\>\"", "->", "\"\<Count things\>\""}]}], 
-      "\[IndentingNewLine]", "|>"}], ",", "\[IndentingNewLine]", 
-     RowBox[{"ChatGPTPluginEndpoint", "[", 
-      RowBox[{"\"\<increment\>\"", ",", 
-       RowBox[{"{", "}"}], ",", 
-       RowBox[{
-        RowBox[{"++", "counter"}], "&"}]}], "]"}]}], "\[IndentingNewLine]", 
-    "]"}]}]}]}], "Input",
+     RowBox[{"\"\<Name\>\"", "->", "\"\<Counter\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<Description\>\"", "->", "\"\<Count things\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<Endpoints\>\"", "->", 
+      RowBox[{"<|", 
+       RowBox[{"\"\<increment\>\"", "->", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"{", "}"}], ",", 
+          RowBox[{
+           RowBox[{"++", "counter"}], "&"}]}], "]"}]}], "|>"}]}]}], 
+    "\[IndentingNewLine]", "|>"}], "]"}]}]}], "Input",
  CellChangeTimes->{{3.8894738330533457`*^9, 3.889473889585083*^9}, {
-  3.889473954404213*^9, 3.8894739552314672`*^9}},
- CellLabel->"In[1]:=",
+  3.889473954404213*^9, 3.8894739552314672`*^9}, {3.8903989505881042`*^9, 
+  3.89039899469226*^9}},
+ CellLabel->"In[2]:=",
  CellID->619953812,ExpressionUUID->"7c1a919f-3354-40a4-a9e2-5de703cc1774"],
 
 Cell[BoxData[
@@ -9820,10 +9635,11 @@ Cell[BoxData[
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {10., {0., 10.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -10001,14 +9817,12 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, {ImageSize -> {Automatic, 
-                Dynamic[
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                  Magnification])]}, AspectRatio -> Automatic, 
-              ImagePadding -> {{0., 0.}, {0., 0.}}, 
-              ImageSize -> {64.43359375, 68.}, 
-              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
-              Automatic}], 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -10026,7 +9840,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640593684741185], {
+                    3610800899943461156], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -10034,29 +9848,33 @@ Cell[BoxData[
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
                     Blank[]] :> Missing["NotAvailable"]}], 
                     Missing["NotAvailable"]], StandardForm], 
+                   ImageSizeCache -> {
+                    11., {0.15937500000000002`, 6.923437500000001}}, 
                    TrackedSymbols :> {
                     ZeroMQLink`PackageScope`$SocketListeners}], 
-                  "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
+                  "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
             PaneBox[
              ButtonBox[
               DynamicBox[
                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+              Appearance -> None, BaseStyle -> {}, 
+              ButtonFunction :> (Typeset`open$$ = False), Evaluator -> 
+              Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -10234,14 +10052,12 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, {ImageSize -> {Automatic, 
-                Dynamic[
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                  Magnification])]}, AspectRatio -> Automatic, 
-              ImagePadding -> {{0., 0.}, {0., 0.}}, 
-              ImageSize -> {64.43359375, 68.}, 
-              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
-              Automatic}], 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -10259,7 +10075,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640593684741185], {
+                    3610800899943461156], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -10377,9 +10193,9 @@ Cell[BoxData[
                     56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
                     43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
                     ImageSize -> {Automatic, 
-                    Dynamic[
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])]}, PlotRange -> {{20, 80}, {0, 70}}, 
+                    Dynamic[3.5 (CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification])]}, 
+                    PlotRange -> {{20, 80}, {0, 70}}, 
                     BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
                     
                     GridBox[{{
@@ -10403,7 +10219,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-a698dc83-1318-40ac-89ed-34c3033da4ec\"", 
+                    "\"TCPSERVER-ecf30a72-ae1b-4c7f-9159-282127adbf0a\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -10510,7 +10326,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-a698dc83-1318-40ac-89ed-34c3033da4ec\"", 
+                    "\"TCPSERVER-ecf30a72-ae1b-4c7f-9159-282127adbf0a\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -10537,33 +10353,33 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-a698dc83-1318-40ac-89ed-34c3033da4ec"], 
-                   Selectable -> False, Editable -> False, SelectWithContents -> 
-                   True], "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
+                   "TCPSERVER-ecf30a72-ae1b-4c7f-9159-282127adbf0a"], 
+                   Editable -> False, SelectWithContents -> True, Selectable -> 
+                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610640593684741185],
+  SocketListener[3610800899943461156],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
  CellChangeTimes->{{3.889473877093595*^9, 3.889473889904319*^9}, 
-   3.889473961324585*^9, 3.8903243470213823`*^9},
- CellLabel->"Out[2]=",
- CellID->129638349,ExpressionUUID->"10df2f37-7f2a-442b-98fb-218eee3ae832"]
+   3.889473961324585*^9, 3.8903243470213823`*^9, 3.890398995845519*^9},
+ CellLabel->"Out[3]=",
+ CellID->184474057,ExpressionUUID->"0c467635-986c-4c5f-b98a-4e6ad59ffda7"]
 }, Open  ]],
 
 Cell["View the initial value of the counter:", "ExampleText",
@@ -12423,7 +12239,7 @@ Cell["Stop the web server:", "ExampleText",
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  CellChangeTimes->{{3.8894738982275467`*^9, 3.88947390025556*^9}},
- CellLabel->"In[3]:=",
+ CellLabel->"In[5]:=",
  CellID->1818981862,ExpressionUUID->"3af5fe9c-a4dd-4518-9399-2d5d90dbde78"]
 }, Open  ]],
 
@@ -12545,7 +12361,7 @@ TaggingRules->{
     "$UseNewPageDialog" -> ""}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "Wolfram/ChatGPTPluginKit"},
-FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
+FrontEndVersion->"13.3 for Mac OS X x86 (64-bit) (April 8, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"02af9b38-5847-4462-9a83-6598f90ff537"
@@ -12556,14 +12372,14 @@ ExpressionUUID->"02af9b38-5847-4462-9a83-6598f90ff537"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[62872, 1346, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"e17586ef-c0f9-4026-b318-29459c49dc32",
+  Cell[53069, 1146, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"e17586ef-c0f9-4026-b318-29459c49dc32",
    CellTags->"ExtendedExamples",
    CellID->523415970]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 696958, 12557}
+ {"ExtendedExamples", 687887, 12373}
  }
 *)
 (*NotebookFileOutline
@@ -12571,245 +12387,237 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 117, 1, 74, "ObjectName",ExpressionUUID->"cf546770-fc27-4178-86b9-6c76b7743af6",
  CellID->2036062166],
-Cell[700, 25, 860, 17, 123, "Usage",ExpressionUUID->"28e7573e-710b-4465-8242-4a06f5ae31e8",
+Cell[700, 25, 925, 19, 123, "Usage",ExpressionUUID->"28e7573e-710b-4465-8242-4a06f5ae31e8",
  CellID->2092392664],
-Cell[1563, 44, 588, 14, 28, "Notes",ExpressionUUID->"4374a6a6-e1a0-4503-9992-d74d486ab093",
+Cell[1628, 46, 588, 14, 28, "Notes",ExpressionUUID->"4374a6a6-e1a0-4503-9992-d74d486ab093",
  CellID->1798784223],
-Cell[2154, 60, 599, 15, 28, "Notes",ExpressionUUID->"eb41cced-7422-463f-9147-04988e3f3795",
+Cell[2219, 62, 599, 15, 28, "Notes",ExpressionUUID->"eb41cced-7422-463f-9147-04988e3f3795",
  CellID->1024735286],
-Cell[2756, 77, 538, 13, 28, "Notes",ExpressionUUID->"7f69d1f7-9102-4e84-8a1f-07341c4c055e",
+Cell[2821, 79, 847, 20, 28, "Notes",ExpressionUUID->"7f69d1f7-9102-4e84-8a1f-07341c4c055e",
  CellID->1735908722],
-Cell[3297, 92, 550, 14, 28, "Notes",ExpressionUUID->"db4d2f57-a9e9-4797-93d7-9ceb51458254",
+Cell[3671, 101, 550, 14, 28, "Notes",ExpressionUUID->"db4d2f57-a9e9-4797-93d7-9ceb51458254",
  CellID->1630866714],
-Cell[3850, 108, 243, 4, 27, "Notes",ExpressionUUID->"05d69e1e-e912-4deb-8d8b-181fb6f1c34e",
+Cell[4224, 117, 243, 4, 27, "Notes",ExpressionUUID->"05d69e1e-e912-4deb-8d8b-181fb6f1c34e",
  CellID->178889690],
-Cell[4096, 114, 185, 2, 27, "Notes",ExpressionUUID->"fc3833f6-4b26-4871-82f3-c6d714ec31a8",
+Cell[4470, 123, 185, 2, 27, "Notes",ExpressionUUID->"fc3833f6-4b26-4871-82f3-c6d714ec31a8",
  CellID->1165676712],
-Cell[4284, 118, 755, 15, 45, "2ColumnTableMod",ExpressionUUID->"5d228e9b-6128-4256-a82d-0c1f022513e4",
+Cell[4658, 127, 755, 15, 45, "2ColumnTableMod",ExpressionUUID->"5d228e9b-6128-4256-a82d-0c1f022513e4",
  CellID->1738984238],
-Cell[5042, 135, 196, 2, 27, "Notes",ExpressionUUID->"72f88175-2618-4ef4-b49b-29f6c62bedfe",
+Cell[5416, 144, 196, 2, 27, "Notes",ExpressionUUID->"72f88175-2618-4ef4-b49b-29f6c62bedfe",
  CellID->1973568911],
-Cell[5241, 139, 641, 11, 43, "2ColumnTableMod",ExpressionUUID->"04f93e12-36b6-4951-9abf-00e3e0d2219c",
+Cell[5615, 148, 641, 11, 43, "2ColumnTableMod",ExpressionUUID->"04f93e12-36b6-4951-9abf-00e3e0d2219c",
  CellID->1484738809],
-Cell[5885, 152, 370, 9, 28, "Notes",ExpressionUUID->"fa6c7d7c-8976-451b-97bc-ad01c9835782",
+Cell[6259, 161, 370, 9, 28, "Notes",ExpressionUUID->"fa6c7d7c-8976-451b-97bc-ad01c9835782",
  CellID->1737601310],
-Cell[6258, 163, 961, 21, 49, "2ColumnTableMod",ExpressionUUID->"d7a6c1b4-c37e-40d9-acb6-37385a5b188b",
+Cell[6632, 172, 961, 21, 49, "2ColumnTableMod",ExpressionUUID->"d7a6c1b4-c37e-40d9-acb6-37385a5b188b",
  CellID->1289514234]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7256, 189, 459, 13, 34, "SeeAlsoSection",ExpressionUUID->"15f78e16-a1af-4409-9375-ccd55f541822",
+Cell[7630, 198, 459, 13, 40, "SeeAlsoSection",ExpressionUUID->"15f78e16-a1af-4409-9375-ccd55f541822",
  CellID->2039137142],
-Cell[7718, 204, 1775, 44, 23, "SeeAlso",ExpressionUUID->"ca0f4ca3-fde5-4926-9c35-4aad6f7c2b9b",
+Cell[8092, 213, 1775, 44, 23, "SeeAlso",ExpressionUUID->"ca0f4ca3-fde5-4926-9c35-4aad6f7c2b9b",
  CellID->86423121]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[9530, 253, 435, 12, 47, "TechNotesSection",ExpressionUUID->"1b20e0a0-6471-40aa-a172-84a409563d0c",
+Cell[9904, 262, 435, 12, 41, "TechNotesSection",ExpressionUUID->"1b20e0a0-6471-40aa-a172-84a409563d0c",
  CellID->814449275],
-Cell[9968, 267, 100, 1, 19, "Tutorials",ExpressionUUID->"54fc0ae8-d630-4a4d-b8bb-b26f1dea589b",
+Cell[10342, 276, 100, 1, 19, "Tutorials",ExpressionUUID->"54fc0ae8-d630-4a4d-b8bb-b26f1dea589b",
  CellID->388198947]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10105, 273, 117, 1, 34, "MoreAboutSection",ExpressionUUID->"afdf4e86-e313-4fe8-bbf4-8d9a872db585",
+Cell[10479, 282, 117, 1, 40, "MoreAboutSection",ExpressionUUID->"afdf4e86-e313-4fe8-bbf4-8d9a872db585",
  CellID->404382643],
-Cell[10225, 276, 101, 1, 19, "MoreAbout",ExpressionUUID->"16cca966-37bb-478b-a0d5-64b5c6effcb0",
+Cell[10599, 285, 101, 1, 19, "MoreAbout",ExpressionUUID->"16cca966-37bb-478b-a0d5-64b5c6effcb0",
  CellID->1820821793]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10363, 282, 472, 13, 34, "RelatedLinksSection",ExpressionUUID->"2a3ff21e-fb6a-46e7-8d9e-536f39452e5e",
+Cell[10737, 291, 472, 13, 40, "RelatedLinksSection",ExpressionUUID->"2a3ff21e-fb6a-46e7-8d9e-536f39452e5e",
  CellID->909905201],
-Cell[10838, 297, 103, 1, 19, "RelatedLinks",ExpressionUUID->"60752c2a-8ef3-49a1-9bea-7cb156508a15",
+Cell[11212, 306, 103, 1, 19, "RelatedLinks",ExpressionUUID->"60752c2a-8ef3-49a1-9bea-7cb156508a15",
  CellID->545662920]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10978, 303, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"00766500-63d6-45c9-a957-a9bbc523089d",
+Cell[11352, 312, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"00766500-63d6-45c9-a957-a9bbc523089d",
  CellID->1201523750],
-Cell[11512, 319, 227, 4, 47, "ExampleInitialization",ExpressionUUID->"f1583514-0533-404e-bd26-af386bd5d22f",
+Cell[11886, 328, 227, 4, 47, "ExampleInitialization",ExpressionUUID->"f1583514-0533-404e-bd26-af386bd5d22f",
  CellID->1220933509]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[11776, 328, 443, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"b4b63811-622c-4c97-bb9f-fd0fcbfaacf8",
+Cell[12150, 337, 443, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"b4b63811-622c-4c97-bb9f-fd0fcbfaacf8",
  CellID->1023238678],
-Cell[12222, 342, 188, 2, 24, "ExampleText",ExpressionUUID->"ddde5435-aacf-4099-b303-8660c4934633",
+Cell[12596, 351, 257, 3, 24, "ExampleText",ExpressionUUID->"ddde5435-aacf-4099-b303-8660c4934633",
  CellID->374440937],
 Cell[CellGroupData[{
-Cell[12435, 348, 869, 20, 142, "Input",ExpressionUUID->"4c0ee421-71dc-4cfe-989d-3f35108998f4",
+Cell[12878, 358, 904, 21, 104, "Input",ExpressionUUID->"4c0ee421-71dc-4cfe-989d-3f35108998f4",
  CellID->428262334],
-Cell[13307, 370, 9793, 194, 53, "Output",ExpressionUUID->"8324416d-f291-4a60-baa5-59170c58cb3f",
- CellID->1988828988]
+Cell[13785, 381, 38809, 749, 53, "Output",ExpressionUUID->"a0e2e263-bf39-4602-a543-b483b6ae2107",
+ CellID->1461594601]
 }, Open  ]],
-Cell[23115, 567, 250, 3, 24, "ExampleText",ExpressionUUID->"267d0710-2c42-486d-b72f-785bd23d6312",
- CellID->1506863819],
-Cell[CellGroupData[{
-Cell[23390, 574, 271, 5, 27, "Input",ExpressionUUID->"3468591e-ff25-45d7-860f-a0fd3906ff53",
- CellID->288831357],
-Cell[23664, 581, 38733, 749, 53, "Output",ExpressionUUID->"714978d2-e987-4f31-85ed-c2282ee244a4",
- CellID->431645507]
-}, Open  ]],
-Cell[62412, 1333, 185, 2, 24, "ExampleText",ExpressionUUID->"2270c8fd-dbb6-4fd0-9577-43b2b832bc7a",
+Cell[52609, 1133, 185, 2, 24, "ExampleText",ExpressionUUID->"2270c8fd-dbb6-4fd0-9577-43b2b832bc7a",
  CellID->1129729877],
-Cell[62600, 1337, 235, 4, 27, "Input",ExpressionUUID->"3634bc9f-131f-45a0-8ce1-05b383133cf9",
+Cell[52797, 1137, 235, 4, 27, "Input",ExpressionUUID->"3634bc9f-131f-45a0-8ce1-05b383133cf9",
  CellID->1952056595]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[62872, 1346, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"e17586ef-c0f9-4026-b318-29459c49dc32",
+Cell[53069, 1146, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"e17586ef-c0f9-4026-b318-29459c49dc32",
  CellTags->"ExtendedExamples",
  CellID->523415970],
 Cell[CellGroupData[{
-Cell[63384, 1363, 241, 5, 35, "ExampleSection",ExpressionUUID->"3a39a644-2a76-40fa-9fce-98ef207fac0d",
+Cell[53581, 1163, 241, 5, 35, "ExampleSection",ExpressionUUID->"3a39a644-2a76-40fa-9fce-98ef207fac0d",
  CellID->959189678],
-Cell[63628, 1370, 411, 9, 26, "ExampleText",ExpressionUUID->"b3cbbf46-1e84-4dbc-a65d-04ec3e8af36b",
+Cell[53825, 1170, 411, 9, 26, "ExampleText",ExpressionUUID->"b3cbbf46-1e84-4dbc-a65d-04ec3e8af36b",
  CellID->726188294],
 Cell[CellGroupData[{
-Cell[64064, 1383, 870, 20, 142, "Input",ExpressionUUID->"88260ee7-e80c-42e4-82c3-bb133e611cc6",
+Cell[54261, 1183, 877, 20, 123, "Input",ExpressionUUID->"88260ee7-e80c-42e4-82c3-bb133e611cc6",
  CellID->1020351672],
-Cell[64937, 1405, 9763, 193, 53, "Output",ExpressionUUID->"dc9dda80-d878-40f1-b0ad-738284d571da",
- CellID->1492314782]
+Cell[55141, 1205, 9952, 198, 53, "Output",ExpressionUUID->"821731f1-f397-4061-a99d-0c24587a4188",
+ CellID->1390859097]
 }, Open  ]],
-Cell[74715, 1601, 188, 2, 24, "ExampleText",ExpressionUUID->"d455e7be-ec66-4f33-9bfe-1507a39230e8",
+Cell[65108, 1406, 188, 2, 24, "ExampleText",ExpressionUUID->"d455e7be-ec66-4f33-9bfe-1507a39230e8",
  CellID->325808286],
 Cell[CellGroupData[{
-Cell[74928, 1607, 682, 18, 66, "Input",ExpressionUUID->"c1e65441-e113-442b-8041-656903d1c0a7",
+Cell[65321, 1412, 682, 18, 66, "Input",ExpressionUUID->"c1e65441-e113-442b-8041-656903d1c0a7",
  CellID->1993786874],
-Cell[75613, 1627, 38958, 754, 53, "Output",ExpressionUUID->"8daf29e1-f9cb-42d4-ae2c-9444fd0119b3",
+Cell[66006, 1432, 38958, 754, 53, "Output",ExpressionUUID->"8daf29e1-f9cb-42d4-ae2c-9444fd0119b3",
  CellID->1242849257]
 }, Open  ]],
-Cell[114586, 2384, 312, 4, 24, "ExampleText",ExpressionUUID->"3b1b94af-3b8e-4679-b46d-6c3da7fdd2e7",
+Cell[104979, 2189, 312, 4, 24, "ExampleText",ExpressionUUID->"3b1b94af-3b8e-4679-b46d-6c3da7fdd2e7",
  CellID->1536036706],
-Cell[114901, 2390, 139212, 2287, 493, "Input",ExpressionUUID->"ba484bc5-c335-4eec-955c-0d91b77c8bb6",
+Cell[105294, 2195, 139212, 2287, 493, "Input",ExpressionUUID->"ba484bc5-c335-4eec-955c-0d91b77c8bb6",
  CellID->476559101],
-Cell[254116, 4679, 240, 4, 24, "ExampleText",ExpressionUUID->"a4df7a33-1800-4b31-ab52-f7b767e9cd8a",
+Cell[244509, 4484, 240, 4, 24, "ExampleText",ExpressionUUID->"a4df7a33-1800-4b31-ab52-f7b767e9cd8a",
  CellID->655976286],
 Cell[CellGroupData[{
-Cell[254381, 4687, 200, 3, 27, "Input",ExpressionUUID->"3285e59e-fd52-4594-a1ca-7aade8c1ea7c",
+Cell[244774, 4492, 200, 3, 27, "Input",ExpressionUUID->"3285e59e-fd52-4594-a1ca-7aade8c1ea7c",
  CellID->972899323],
-Cell[254584, 4692, 43891, 928, 453, "Output",ExpressionUUID->"1e98b6c3-ad49-4e4b-bfe3-b41da3de006d",
+Cell[244977, 4497, 43891, 928, 453, "Output",ExpressionUUID->"1e98b6c3-ad49-4e4b-bfe3-b41da3de006d",
  CellID->570947987]
 }, Open  ]],
-Cell[298490, 5623, 185, 2, 24, "ExampleText",ExpressionUUID->"ee35cb36-d580-4ea9-8e8c-3fecd6c5ade2",
+Cell[288883, 5428, 185, 2, 24, "ExampleText",ExpressionUUID->"ee35cb36-d580-4ea9-8e8c-3fecd6c5ade2",
  CellID->1820825470],
-Cell[298678, 5627, 234, 4, 27, "Input",ExpressionUUID->"a29047ac-c603-49ae-a6f7-a1de767a57f0",
+Cell[289071, 5432, 234, 4, 27, "Input",ExpressionUUID->"a29047ac-c603-49ae-a6f7-a1de767a57f0",
  CellID->971704540]
 }, Open  ]],
-Cell[298927, 5634, 265, 5, 35, "ExampleSection",ExpressionUUID->"97378e9e-619d-4649-8b5b-9910e6455c36",
+Cell[289320, 5439, 265, 5, 35, "ExampleSection",ExpressionUUID->"97378e9e-619d-4649-8b5b-9910e6455c36",
  CellID->2088663764],
 Cell[CellGroupData[{
-Cell[299217, 5643, 244, 5, 23, "ExampleSection",ExpressionUUID->"0a61a72c-dfe1-4a89-b435-d55a8accc5c0",
+Cell[289610, 5448, 244, 5, 23, "ExampleSection",ExpressionUUID->"0a61a72c-dfe1-4a89-b435-d55a8accc5c0",
  CellID->1404187686],
-Cell[299464, 5650, 247, 5, 26, "ExampleSubsection",ExpressionUUID->"406a0834-353c-454c-a6ff-4c60e9cecd26",
+Cell[289857, 5455, 247, 5, 26, "ExampleSubsection",ExpressionUUID->"406a0834-353c-454c-a6ff-4c60e9cecd26",
  CellID->1484641719],
-Cell[299714, 5657, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"c6befcac-5957-4f91-8cf7-8393bab90f78",
+Cell[290107, 5462, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"c6befcac-5957-4f91-8cf7-8393bab90f78",
  CellID->760876740]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[299997, 5667, 249, 5, 35, "ExampleSection",ExpressionUUID->"ad9b81e7-d822-4ad7-9437-bfb4bf8953f1",
+Cell[290390, 5472, 249, 5, 35, "ExampleSection",ExpressionUUID->"ad9b81e7-d822-4ad7-9437-bfb4bf8953f1",
  CellID->1937734942],
-Cell[300249, 5674, 196, 2, 24, "ExampleText",ExpressionUUID->"3bb7e803-af35-4b11-aa10-6c815b785c85",
+Cell[290642, 5479, 196, 2, 24, "ExampleText",ExpressionUUID->"3bb7e803-af35-4b11-aa10-6c815b785c85",
  CellID->1274307077],
 Cell[CellGroupData[{
-Cell[300470, 5680, 3088, 70, 389, "Input",ExpressionUUID->"4da1c156-9ede-43e7-825f-4a813266e782",
+Cell[290863, 5485, 3302, 73, 389, "Input",ExpressionUUID->"4da1c156-9ede-43e7-825f-4a813266e782",
  CellID->41348088],
-Cell[303561, 5752, 38987, 755, 53, "Output",ExpressionUUID->"e9e003c5-586b-4415-8f9f-fcce0389172a",
+Cell[294168, 5560, 38987, 755, 53, "Output",ExpressionUUID->"e9e003c5-586b-4415-8f9f-fcce0389172a",
  CellID->434523012]
 }, Open  ]],
-Cell[342563, 6510, 194, 2, 24, "ExampleText",ExpressionUUID->"f5d36ea9-bfc7-4d39-82b9-b3597439e9dd",
+Cell[333170, 6318, 194, 2, 24, "ExampleText",ExpressionUUID->"f5d36ea9-bfc7-4d39-82b9-b3597439e9dd",
  CellID->1668834681],
-Cell[342760, 6514, 195945, 3217, 557, "Input",ExpressionUUID->"486aee5e-7ffe-4464-a34e-31914f5235bd",
+Cell[333367, 6322, 195945, 3217, 557, "Input",ExpressionUUID->"486aee5e-7ffe-4464-a34e-31914f5235bd",
  CellID->1491546085],
-Cell[538708, 9733, 204, 2, 24, "ExampleText",ExpressionUUID->"db75a92b-6a80-46b5-8bf7-3ef586ced074",
+Cell[529315, 9541, 204, 2, 24, "ExampleText",ExpressionUUID->"db75a92b-6a80-46b5-8bf7-3ef586ced074",
  CellID->187979416],
 Cell[CellGroupData[{
-Cell[538937, 9739, 198, 3, 27, "Input",ExpressionUUID->"93cbc79b-4c0c-4d58-820b-ade59f8cfa2d",
+Cell[529544, 9547, 198, 3, 27, "Input",ExpressionUUID->"93cbc79b-4c0c-4d58-820b-ade59f8cfa2d",
  CellID->1387489144],
-Cell[539138, 9744, 319, 7, 28, "Output",ExpressionUUID->"ba865546-63f7-4267-ac40-d8d9a065f9f7",
+Cell[529745, 9552, 319, 7, 26, "Output",ExpressionUUID->"ba865546-63f7-4267-ac40-d8d9a065f9f7",
  CellID->603970918]
 }, Open  ]],
-Cell[539472, 9754, 212, 3, 24, "ExampleText",ExpressionUUID->"9dee768c-7657-4089-9c00-43cd060dae03",
+Cell[530079, 9562, 212, 3, 24, "ExampleText",ExpressionUUID->"9dee768c-7657-4089-9c00-43cd060dae03",
  CellID->576310274],
-Cell[539687, 9759, 234, 4, 27, "Input",ExpressionUUID->"b0de1bd6-d21f-43cc-bc0b-d066899ae825",
+Cell[530294, 9567, 234, 4, 27, "Input",ExpressionUUID->"b0de1bd6-d21f-43cc-bc0b-d066899ae825",
  CellID->895527148]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[539958, 9768, 258, 5, 35, "ExampleSection",ExpressionUUID->"151e9e8c-26a4-4ddb-93b7-f395aa69d2f8",
+Cell[530565, 9576, 258, 5, 35, "ExampleSection",ExpressionUUID->"151e9e8c-26a4-4ddb-93b7-f395aa69d2f8",
  CellID->921663439],
-Cell[540219, 9775, 383, 7, 41, "ExampleText",ExpressionUUID->"1c0a2a09-3953-4129-8383-f50746993bd4",
+Cell[530826, 9583, 383, 7, 41, "ExampleText",ExpressionUUID->"1c0a2a09-3953-4129-8383-f50746993bd4",
  CellID->287202388],
+Cell[531212, 9592, 189, 3, 27, "Input",ExpressionUUID->"74a8e071-d4ff-4212-a1cd-9b1341f2e321",
+ CellID->1160191379],
 Cell[CellGroupData[{
-Cell[540627, 9786, 928, 22, 142, "Input",ExpressionUUID->"7c1a919f-3354-40a4-a9e2-5de703cc1774",
+Cell[531426, 9599, 989, 24, 123, "Input",ExpressionUUID->"7c1a919f-3354-40a4-a9e2-5de703cc1774",
  CellID->619953812],
-Cell[541558, 9810, 39009, 755, 53, "Output",ExpressionUUID->"10df2f37-7f2a-442b-98fb-218eee3ae832",
- CellID->129638349]
+Cell[532418, 9625, 39082, 756, 53, "Output",ExpressionUUID->"0c467635-986c-4c5f-b98a-4e6ad59ffda7",
+ CellID->184474057]
 }, Open  ]],
-Cell[580582, 10568, 202, 2, 24, "ExampleText",ExpressionUUID->"882f5b78-232e-46b5-a6fc-c822d5f4a53b",
+Cell[571515, 10384, 202, 2, 24, "ExampleText",ExpressionUUID->"882f5b78-232e-46b5-a6fc-c822d5f4a53b",
  CellID->1883651148],
 Cell[CellGroupData[{
-Cell[580809, 10574, 199, 3, 27, "Input",ExpressionUUID->"dc9655d4-5c55-4d35-aed6-25a14fc0db3b",
+Cell[571742, 10390, 199, 3, 27, "Input",ExpressionUUID->"dc9655d4-5c55-4d35-aed6-25a14fc0db3b",
  CellID->1826074982],
-Cell[581011, 10579, 192, 3, 26, "Output",ExpressionUUID->"21767453-6a4b-46d1-8db7-7bb38bd10616",
+Cell[571944, 10395, 192, 3, 26, "Output",ExpressionUUID->"21767453-6a4b-46d1-8db7-7bb38bd10616",
  CellID->1617131376]
 }, Open  ]],
-Cell[581218, 10585, 279, 4, 24, "ExampleText",ExpressionUUID->"583a1a4b-4c90-46b1-81d9-48f5cd1bdbc6",
+Cell[572151, 10401, 279, 4, 24, "ExampleText",ExpressionUUID->"583a1a4b-4c90-46b1-81d9-48f5cd1bdbc6",
  CellID->234368142],
-Cell[581500, 10591, 109989, 1808, 402, "Input",ExpressionUUID->"a6d84755-96a1-43cc-8672-8f56f169ad96",
+Cell[572433, 10407, 109989, 1808, 402, "Input",ExpressionUUID->"a6d84755-96a1-43cc-8672-8f56f169ad96",
  CellID->281002211],
-Cell[691492, 12401, 198, 2, 24, "ExampleText",ExpressionUUID->"54e3b863-bca2-451a-ba39-a1dfbddeeb61",
+Cell[682425, 12217, 198, 2, 24, "ExampleText",ExpressionUUID->"54e3b863-bca2-451a-ba39-a1dfbddeeb61",
  CellID->457176607],
 Cell[CellGroupData[{
-Cell[691715, 12407, 199, 3, 27, "Input",ExpressionUUID->"4b7236db-11b2-4c6f-a5d8-2fe6c68ca7ec",
+Cell[682648, 12223, 199, 3, 27, "Input",ExpressionUUID->"4b7236db-11b2-4c6f-a5d8-2fe6c68ca7ec",
  CellID->1907463776],
-Cell[691917, 12412, 169, 3, 26, "Output",ExpressionUUID->"772e94d3-df50-4985-a6dc-97268419837c",
+Cell[682850, 12228, 169, 3, 26, "Output",ExpressionUUID->"772e94d3-df50-4985-a6dc-97268419837c",
  CellID->1485341704]
 }, Open  ]],
-Cell[692101, 12418, 187, 2, 24, "ExampleText",ExpressionUUID->"1978b8ba-17d2-4b18-8383-736dff9972d1",
+Cell[683034, 12234, 187, 2, 24, "ExampleText",ExpressionUUID->"1978b8ba-17d2-4b18-8383-736dff9972d1",
  CellID->2023959105],
-Cell[692291, 12422, 236, 4, 27, "Input",ExpressionUUID->"3af5fe9c-a4dd-4518-9399-2d5d90dbde78",
+Cell[683224, 12238, 236, 4, 27, "Input",ExpressionUUID->"3af5fe9c-a4dd-4518-9399-2d5d90dbde78",
  CellID->1818981862]
 }, Open  ]],
-Cell[692542, 12429, 251, 5, 35, "ExampleSection",ExpressionUUID->"6907c361-efc4-446b-9590-445c655cc792",
+Cell[683475, 12245, 251, 5, 35, "ExampleSection",ExpressionUUID->"6907c361-efc4-446b-9590-445c655cc792",
  CellID->597873462],
-Cell[692796, 12436, 256, 5, 23, "ExampleSection",ExpressionUUID->"f57594bf-f01c-41cc-b979-e233d8650408",
+Cell[683729, 12252, 256, 5, 23, "ExampleSection",ExpressionUUID->"f57594bf-f01c-41cc-b979-e233d8650408",
  CellID->383291521],
-Cell[693055, 12443, 250, 5, 23, "ExampleSection",ExpressionUUID->"902c6450-a0d6-42e1-b56d-a6cfe1c7cf82",
+Cell[683988, 12259, 250, 5, 23, "ExampleSection",ExpressionUUID->"902c6450-a0d6-42e1-b56d-a6cfe1c7cf82",
  CellID->1677136094]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[693342, 12453, 111, 1, 72, "MetadataSection",ExpressionUUID->"7a126ea0-0c32-4faf-a197-641aa2b62352",
+Cell[684275, 12269, 111, 1, 72, "MetadataSection",ExpressionUUID->"7a126ea0-0c32-4faf-a197-641aa2b62352",
  CellID->1903464983],
-Cell[693456, 12456, 476, 12, 26, "History",ExpressionUUID->"be06909b-e576-4433-a281-1f1aeed1b5e2",
+Cell[684389, 12272, 476, 12, 26, "History",ExpressionUUID->"be06909b-e576-4433-a281-1f1aeed1b5e2",
  CellID->472079922],
 Cell[CellGroupData[{
-Cell[693957, 12472, 485, 13, 21, "CategorizationSection",ExpressionUUID->"b4cc9a10-b1f4-4a5b-a25b-3f4fdd26ab8e",
+Cell[684890, 12288, 485, 13, 21, "CategorizationSection",ExpressionUUID->"b4cc9a10-b1f4-4a5b-a25b-3f4fdd26ab8e",
  CellID->1442657036],
-Cell[694445, 12487, 135, 2, 35, "Categorization",ExpressionUUID->"993aca31-458d-4ba3-a4bf-1b5811269aca",
+Cell[685378, 12303, 135, 2, 35, "Categorization",ExpressionUUID->"993aca31-458d-4ba3-a4bf-1b5811269aca",
  CellID->1646429422],
-Cell[694583, 12491, 153, 2, 35, "Categorization",ExpressionUUID->"0d34c942-6e76-4412-a239-0a3e2aac94e7",
+Cell[685516, 12307, 153, 2, 35, "Categorization",ExpressionUUID->"0d34c942-6e76-4412-a239-0a3e2aac94e7",
  CellID->1212503959],
-Cell[694739, 12495, 150, 2, 35, "Categorization",ExpressionUUID->"bc6bab4d-9c68-43ec-b53f-8ff59b997d4b",
+Cell[685672, 12311, 150, 2, 35, "Categorization",ExpressionUUID->"bc6bab4d-9c68-43ec-b53f-8ff59b997d4b",
  CellID->1081712530],
-Cell[694892, 12499, 169, 2, 35, "Categorization",ExpressionUUID->"ffe93d74-5e77-423c-8a55-90fafcd2997f",
+Cell[685825, 12315, 169, 2, 35, "Categorization",ExpressionUUID->"ffe93d74-5e77-423c-8a55-90fafcd2997f",
  CellID->1893419855]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[695098, 12506, 111, 1, 31, "KeywordsSection",ExpressionUUID->"d7df0952-d28b-4671-8db6-41695258a343",
+Cell[686031, 12322, 111, 1, 31, "KeywordsSection",ExpressionUUID->"d7df0952-d28b-4671-8db6-41695258a343",
  CellID->1294821739],
-Cell[695212, 12509, 100, 1, 70, "Keywords",ExpressionUUID->"9dd93ff3-14a7-4952-868e-97cc815fd1da",
+Cell[686145, 12325, 100, 1, 70, "Keywords",ExpressionUUID->"9dd93ff3-14a7-4952-868e-97cc815fd1da",
  CellID->1617172322]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[695349, 12515, 120, 1, 21, "TemplatesSection",ExpressionUUID->"86de037b-21a3-4ecd-85f5-96f98dd05436",
+Cell[686282, 12331, 120, 1, 21, "TemplatesSection",ExpressionUUID->"86de037b-21a3-4ecd-85f5-96f98dd05436",
  CellID->1262179422],
-Cell[695472, 12518, 148, 2, 70, "Template",ExpressionUUID->"f3aebcc1-8c5c-4bd4-bfa9-b739c7209563",
+Cell[686405, 12334, 148, 2, 70, "Template",ExpressionUUID->"f3aebcc1-8c5c-4bd4-bfa9-b739c7209563",
  CellID->606080488],
-Cell[695623, 12522, 137, 2, 70, "Template",ExpressionUUID->"9d6a20bd-2eef-4716-b51b-c459b203a41a",
+Cell[686556, 12338, 137, 2, 70, "Template",ExpressionUUID->"9d6a20bd-2eef-4716-b51b-c459b203a41a",
  CellID->879824095],
-Cell[695763, 12526, 136, 2, 70, "Template",ExpressionUUID->"cce32400-3e47-47da-a779-c20a1d364cce",
+Cell[686696, 12342, 136, 2, 70, "Template",ExpressionUUID->"cce32400-3e47-47da-a779-c20a1d364cce",
  CellID->1778655070],
-Cell[695902, 12530, 137, 2, 70, "Template",ExpressionUUID->"8649aeb0-d743-421e-a624-574b167d4bfc",
+Cell[686835, 12346, 137, 2, 70, "Template",ExpressionUUID->"8649aeb0-d743-421e-a624-574b167d4bfc",
  CellID->883395250]
 }, Closed]]
 }, Open  ]]
 }
 ]
 *)
-
-(* End of internal cache information *)
 

--- a/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPluginEndpoint.nb
+++ b/ChatGPTPluginKit/Documentation/English/ReferencePages/Symbols/ChatGPTPluginEndpoint.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     28501,        732]
-NotebookOptionsPosition[     21239,        579]
-NotebookOutlinePosition[     22403,        612]
-CellTagsIndexPosition[     22324,        607]
+NotebookDataLength[     30345,        772]
+NotebookOptionsPosition[     22844,        615]
+NotebookOutlinePosition[     24004,        648]
+CellTagsIndexPosition[     23925,        643]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -45,10 +45,19 @@ parameters, and function body.\n",
     StyleBox["params", "TI"], ",", 
     StyleBox["fun", "TI"]}], "]"}]], "InlineFormula",ExpressionUUID->
   "86f876df-e412-4987-8d84-f78c2a40030f"],
- "\[LineSeparator]Associates the specified prompt with the endpoint."
+ "\[LineSeparator]Associates the specified prompt with the endpoint.\n",
+ Cell["   ", "ModInfo",ExpressionUUID->"f05b4afa-57c3-4d55-b7c7-6f88b5b07278"],
+ Cell[BoxData[
+  RowBox[{"ChatGPTPluginEndpoint", "[", 
+   RowBox[{
+    StyleBox["name", "TI"], ",", 
+    StyleBox["assoc", "TI"]}], "]"}]], "InlineFormula",ExpressionUUID->
+  "ecf66c2d-5a39-443c-a34f-bf8278aebbc5"],
+ "\[LineSeparator]Uses an association to specify and endpoint."
 }], "Usage",
  CellChangeTimes->{{3.889460034535874*^9, 3.889460085592732*^9}, {
-  3.889484574051124*^9, 3.889484601746159*^9}},
+  3.889484574051124*^9, 3.889484601746159*^9}, {3.890399074338606*^9, 
+  3.890399106303656*^9}, {3.8903992036133204`*^9, 3.890399208855879*^9}},
  CellID->1653225615,ExpressionUUID->"4b991515-d159-420e-8c18-e40177cee29d"],
 
 Cell[TextData[{
@@ -134,7 +143,34 @@ Cell[TextData[{
  " is applied to an association with keys for each of the input parameters."
 }], "Notes",
  CellChangeTimes->{{3.889460542790601*^9, 3.889460575772822*^9}},
- CellID->742353863,ExpressionUUID->"caea48bf-9265-4774-a14d-29b07da69780"]
+ CellID->742353863,ExpressionUUID->"caea48bf-9265-4774-a14d-29b07da69780"],
+
+Cell[TextData[{
+ Cell[BoxData[
+  StyleBox["assoc", "TI"]], "InlineFormula",ExpressionUUID->
+  "dd79682a-c10f-4a57-b5cf-f76a486b9b27"],
+ " can include the following keys:"
+}], "Notes",
+ CellChangeTimes->{{3.890399114367832*^9, 3.890399126239596*^9}},
+ CellID->494064204,ExpressionUUID->"8f32bda5-9fa8-4d44-9b8a-f8c6f78d71db"],
+
+Cell[BoxData[GridBox[{
+   {Cell["      ", "ModInfo",ExpressionUUID->
+     "46aab53e-e5ba-4008-869e-23fb42bd4f24"], "\"\<Prompt\>\"", Cell[
+    "prompt", "TableText",ExpressionUUID->
+     "dd844bf7-e03c-4295-b4b1-1eb4f87bc254"]},
+   {Cell["      ", "ModInfo",ExpressionUUID->
+     "c2f9002c-2641-4ebe-b9e1-409d7c64cb95"], "\"\<APIFunction\>\"", Cell[
+    TextData[{
+     Cell[BoxData[
+      ButtonBox["APIFunction",
+       BaseStyle->"Link"]], "InlineFormula",ExpressionUUID->
+      "dd20d89c-cc9b-432f-bbcf-a9ec06739a48"],
+     " defining parameters and body (required)"
+    }], "TableText",ExpressionUUID->"2a955acc-c36b-418b-97f1-8501fd58b84e"]}
+  }]], "2ColumnTableMod",
+ CellChangeTimes->{{3.890399154576005*^9, 3.890399244351823*^9}},
+ CellID->363677027,ExpressionUUID->"c5ad02f1-0033-4161-a50f-1f40b07e57a8"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -169,10 +205,10 @@ Cell[TextData[{
     "4a86444d-d946-4671-9a36-742f60be024f"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "b3d8cb14-ff9e-4c37-8fdd-2935b39e9382", 
-     "aa93ce69-a5ac-4309-a177-d061fe4c3e50"], $CellContext`cellobj$$ = 
+     "3cfeecc3-8664-402f-8cf8-800dd508e064"], $CellContext`cellobj$$ = 
     CellObject[
     "0634900f-d47d-4657-9f2f-d617682323a2", 
-     "295869d7-b9cd-4838-85a6-6409c4fd4962"]}, 
+     "8f3bde9d-d27e-450c-a114-aefca03d4fb9"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -578,7 +614,7 @@ Cell[BoxData[""], "Template",
 }, Open  ]]
 },
 WindowSize->{700, 770},
-WindowMargins->{{Automatic, 427}, {Automatic, 35}},
+WindowMargins->{{484, Automatic}, {Automatic, 42}},
 TaggingRules->{
  "DocuToolsSettingsInternal" -> {
    "$PacletVersion" -> "0.10.2323", "$ApplicationName" -> "Mathematica", 
@@ -588,7 +624,7 @@ TaggingRules->{
     "$UseNewPageDialog" -> ""}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "Wolfram/ChatGPTPluginKit"},
-FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
+FrontEndVersion->"13.3 for Mac OS X x86 (64-bit) (April 8, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"b3d8cb14-ff9e-4c37-8fdd-2935b39e9382"
@@ -599,14 +635,14 @@ ExpressionUUID->"b3d8cb14-ff9e-4c37-8fdd-2935b39e9382"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[15417, 405, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"ca8d1482-b8bc-4c58-9964-4052abdfc8a8",
+  Cell[17022, 441, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"ca8d1482-b8bc-4c58-9964-4052abdfc8a8",
    CellTags->"ExtendedExamples",
    CellID->795220415]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 22130, 600}
+ {"ExtendedExamples", 23731, 636}
  }
 *)
 (*NotebookFileOutline
@@ -614,129 +650,131 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 119, 1, 74, "ObjectName",ExpressionUUID->"a524aeb2-32a7-4a66-9e50-d0023888bf4c",
  CellID->1789944913],
-Cell[702, 25, 1136, 26, 123, "Usage",ExpressionUUID->"4b991515-d159-420e-8c18-e40177cee29d",
+Cell[702, 25, 1597, 35, 166, "Usage",ExpressionUUID->"4b991515-d159-420e-8c18-e40177cee29d",
  CellID->1653225615],
-Cell[1841, 53, 418, 8, 45, "Notes",ExpressionUUID->"99e0d199-53a6-485b-9e93-db52cd24ae7d",
+Cell[2302, 62, 418, 8, 45, "Notes",ExpressionUUID->"99e0d199-53a6-485b-9e93-db52cd24ae7d",
  CellID->1158657570],
-Cell[2262, 63, 614, 13, 27, "Notes",ExpressionUUID->"dfe37d5e-75cc-40b6-9306-6fb0a3b3a5a6",
+Cell[2723, 72, 614, 13, 27, "Notes",ExpressionUUID->"dfe37d5e-75cc-40b6-9306-6fb0a3b3a5a6",
  CellID->1619486419],
-Cell[2879, 78, 1161, 21, 61, "2ColumnTableMod",ExpressionUUID->"a6a4ff61-ef6b-459a-8096-54d8c5a9a15a",
+Cell[3340, 87, 1161, 21, 61, "2ColumnTableMod",ExpressionUUID->"a6a4ff61-ef6b-459a-8096-54d8c5a9a15a",
  CellID->558862579],
-Cell[4043, 101, 326, 8, 27, "Notes",ExpressionUUID->"e8a0ef78-4ba3-4059-8dbd-75fbc05e6af3",
+Cell[4504, 110, 326, 8, 27, "Notes",ExpressionUUID->"e8a0ef78-4ba3-4059-8dbd-75fbc05e6af3",
  CellID->1530865763],
-Cell[4372, 111, 867, 15, 61, "2ColumnTableMod",ExpressionUUID->"b8e6d2cd-1ccf-40a8-b0c6-b26be4de377a",
+Cell[4833, 120, 867, 15, 61, "2ColumnTableMod",ExpressionUUID->"b8e6d2cd-1ccf-40a8-b0c6-b26be4de377a",
  CellID->1167989943],
-Cell[5242, 128, 397, 8, 27, "Notes",ExpressionUUID->"caea48bf-9265-4774-a14d-29b07da69780",
- CellID->742353863]
+Cell[5703, 137, 397, 8, 27, "Notes",ExpressionUUID->"caea48bf-9265-4774-a14d-29b07da69780",
+ CellID->742353863],
+Cell[6103, 147, 324, 7, 27, "Notes",ExpressionUUID->"8f32bda5-9fa8-4d44-9b8a-f8c6f78d71db",
+ CellID->494064204],
+Cell[6430, 156, 814, 16, 45, "2ColumnTableMod",ExpressionUUID->"c5ad02f1-0033-4161-a50f-1f40b07e57a8",
+ CellID->363677027]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[5676, 141, 459, 13, 34, "SeeAlsoSection",ExpressionUUID->"375609b4-aaed-4964-9336-a83ba30a3217",
+Cell[7281, 177, 459, 13, 40, "SeeAlsoSection",ExpressionUUID->"375609b4-aaed-4964-9336-a83ba30a3217",
  CellID->1500502055],
-Cell[6138, 156, 1777, 44, 23, "SeeAlso",ExpressionUUID->"0b41888f-6d22-4164-98db-616c1af1700c",
+Cell[7743, 192, 1777, 44, 23, "SeeAlso",ExpressionUUID->"0b41888f-6d22-4164-98db-616c1af1700c",
  CellID->1037571664]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7952, 205, 435, 12, 47, "TechNotesSection",ExpressionUUID->"b6323982-ba68-4f46-abda-b5672f0965f3",
+Cell[9557, 241, 435, 12, 41, "TechNotesSection",ExpressionUUID->"b6323982-ba68-4f46-abda-b5672f0965f3",
  CellID->899743208],
-Cell[8390, 219, 101, 1, 19, "Tutorials",ExpressionUUID->"fe8b9ad7-d4b5-4639-9d21-79613212d55e",
+Cell[9995, 255, 101, 1, 19, "Tutorials",ExpressionUUID->"fe8b9ad7-d4b5-4639-9d21-79613212d55e",
  CellID->1551738329]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[8528, 225, 118, 1, 34, "MoreAboutSection",ExpressionUUID->"bfa19dce-ebf4-469e-b5e2-97941b04131f",
+Cell[10133, 261, 118, 1, 40, "MoreAboutSection",ExpressionUUID->"bfa19dce-ebf4-469e-b5e2-97941b04131f",
  CellID->1024686335],
-Cell[8649, 228, 101, 1, 19, "MoreAbout",ExpressionUUID->"6fa35e52-d12d-4c61-83bd-de35c95ebae6",
+Cell[10254, 264, 101, 1, 19, "MoreAbout",ExpressionUUID->"6fa35e52-d12d-4c61-83bd-de35c95ebae6",
  CellID->1231867052]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[8787, 234, 471, 13, 34, "RelatedLinksSection",ExpressionUUID->"e5f839fe-2bc0-49d6-b8a7-f324292862de",
+Cell[10392, 270, 471, 13, 40, "RelatedLinksSection",ExpressionUUID->"e5f839fe-2bc0-49d6-b8a7-f324292862de",
  CellID->99702237],
-Cell[9261, 249, 103, 1, 19, "RelatedLinks",ExpressionUUID->"d4c3c9ba-fc05-426f-91fe-317d95cdfd42",
+Cell[10866, 285, 103, 1, 19, "RelatedLinks",ExpressionUUID->"d4c3c9ba-fc05-426f-91fe-317d95cdfd42",
  CellID->658252599]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[9401, 255, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"6fef9b2e-a376-4e81-9065-3ba1bd278f16",
+Cell[11006, 291, 531, 14, 70, "ExamplesInitializationSection",ExpressionUUID->"6fef9b2e-a376-4e81-9065-3ba1bd278f16",
  CellID->1563165696],
-Cell[9935, 271, 229, 4, 47, "ExampleInitialization",ExpressionUUID->"e3801c33-1667-485a-9d76-30761d40060d",
+Cell[11540, 307, 229, 4, 47, "ExampleInitialization",ExpressionUUID->"e3801c33-1667-485a-9d76-30761d40060d",
  CellID->1958398921]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10201, 280, 442, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"2ad35463-b7d3-48b8-b523-5d6249704426",
+Cell[11806, 316, 442, 12, 73, "PrimaryExamplesSection",ExpressionUUID->"2ad35463-b7d3-48b8-b523-5d6249704426",
  CellID->328807678],
-Cell[10646, 294, 235, 4, 24, "ExampleText",ExpressionUUID->"1e1a3bd7-0104-44e3-a1e3-9c9a251ae768",
+Cell[12251, 330, 235, 4, 24, "ExampleText",ExpressionUUID->"1e1a3bd7-0104-44e3-a1e3-9c9a251ae768",
  CellID->449440125],
 Cell[CellGroupData[{
-Cell[10906, 302, 413, 8, 27, "Input",ExpressionUUID->"5a631fe9-8d43-4694-b86f-d763131b6b3a",
+Cell[12511, 338, 413, 8, 27, "Input",ExpressionUUID->"5a631fe9-8d43-4694-b86f-d763131b6b3a",
  CellID->1082447407],
-Cell[11322, 312, 4046, 87, 52, "Output",ExpressionUUID->"d2edf077-e08f-4d4d-9744-103d0bc9d616",
+Cell[12927, 348, 4046, 87, 52, "Output",ExpressionUUID->"d2edf077-e08f-4d4d-9744-103d0bc9d616",
  CellID->1309045448]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[15417, 405, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"ca8d1482-b8bc-4c58-9964-4052abdfc8a8",
+Cell[17022, 441, 487, 13, 58, "ExtendedExamplesSection",ExpressionUUID->"ca8d1482-b8bc-4c58-9964-4052abdfc8a8",
  CellTags->"ExtendedExamples",
  CellID->795220415],
-Cell[15907, 420, 242, 5, 35, "ExampleSection",ExpressionUUID->"51046524-7046-42a7-859b-fee0caf65bec",
+Cell[17512, 456, 242, 5, 35, "ExampleSection",ExpressionUUID->"51046524-7046-42a7-859b-fee0caf65bec",
  CellID->1478779624],
-Cell[16152, 427, 265, 5, 23, "ExampleSection",ExpressionUUID->"9fcb69f9-1ac3-48c5-82d1-5cd7063cd106",
+Cell[17757, 463, 265, 5, 23, "ExampleSection",ExpressionUUID->"9fcb69f9-1ac3-48c5-82d1-5cd7063cd106",
  CellID->1020893837],
 Cell[CellGroupData[{
-Cell[16442, 436, 244, 5, 23, "ExampleSection",ExpressionUUID->"b2be4fbd-d0df-46f2-84ac-5a217e460339",
+Cell[18047, 472, 244, 5, 23, "ExampleSection",ExpressionUUID->"b2be4fbd-d0df-46f2-84ac-5a217e460339",
  CellID->1915862576],
-Cell[16689, 443, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"7af7eb53-be52-4e43-8aba-70d27707423b",
+Cell[18294, 479, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"7af7eb53-be52-4e43-8aba-70d27707423b",
  CellID->532511714],
-Cell[16938, 450, 247, 5, 22, "ExampleSubsection",ExpressionUUID->"c18b2e08-90b3-421e-a8f4-60f565b1d131",
+Cell[18543, 486, 247, 5, 22, "ExampleSubsection",ExpressionUUID->"c18b2e08-90b3-421e-a8f4-60f565b1d131",
  CellID->1360020149]
 }, Open  ]],
-Cell[17200, 458, 247, 5, 35, "ExampleSection",ExpressionUUID->"848a3b53-1a17-4159-b18d-a21865959e4b",
+Cell[18805, 494, 247, 5, 35, "ExampleSection",ExpressionUUID->"848a3b53-1a17-4159-b18d-a21865959e4b",
  CellID->42705575],
-Cell[17450, 465, 258, 5, 23, "ExampleSection",ExpressionUUID->"29be0de6-2117-4ed0-8d68-5ee99e780b9f",
+Cell[19055, 501, 258, 5, 23, "ExampleSection",ExpressionUUID->"29be0de6-2117-4ed0-8d68-5ee99e780b9f",
  CellID->493060927],
-Cell[17711, 472, 252, 5, 23, "ExampleSection",ExpressionUUID->"0516ca62-b071-4906-9ecc-7110531e182b",
+Cell[19316, 508, 252, 5, 23, "ExampleSection",ExpressionUUID->"0516ca62-b071-4906-9ecc-7110531e182b",
  CellID->1883089963],
-Cell[17966, 479, 257, 5, 23, "ExampleSection",ExpressionUUID->"03736a74-ba30-4593-ad8d-5c5d3e6a6e51",
+Cell[19571, 515, 257, 5, 23, "ExampleSection",ExpressionUUID->"03736a74-ba30-4593-ad8d-5c5d3e6a6e51",
  CellID->1626502302],
-Cell[18226, 486, 250, 5, 23, "ExampleSection",ExpressionUUID->"cc96537d-fede-405c-b741-7af10950d189",
+Cell[19831, 522, 250, 5, 23, "ExampleSection",ExpressionUUID->"cc96537d-fede-405c-b741-7af10950d189",
  CellID->1304847051]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18513, 496, 110, 1, 72, "MetadataSection",ExpressionUUID->"ecc33bd3-8dcd-4456-95f5-0680b5507a96",
+Cell[20118, 532, 110, 1, 72, "MetadataSection",ExpressionUUID->"ecc33bd3-8dcd-4456-95f5-0680b5507a96",
  CellID->461382993],
-Cell[18626, 499, 477, 12, 26, "History",ExpressionUUID->"88e2e177-8700-4b03-a8b1-08e55712df46",
+Cell[20231, 535, 477, 12, 26, "History",ExpressionUUID->"88e2e177-8700-4b03-a8b1-08e55712df46",
  CellID->2047997681],
 Cell[CellGroupData[{
-Cell[19128, 515, 484, 13, 21, "CategorizationSection",ExpressionUUID->"82449b88-71df-422c-af42-c1ee7fc1583b",
+Cell[20733, 551, 484, 13, 21, "CategorizationSection",ExpressionUUID->"82449b88-71df-422c-af42-c1ee7fc1583b",
  CellID->829130451],
-Cell[19615, 530, 134, 2, 35, "Categorization",ExpressionUUID->"987fde4b-8985-4b0a-8b19-c0d5877d66a2",
+Cell[21220, 566, 134, 2, 35, "Categorization",ExpressionUUID->"987fde4b-8985-4b0a-8b19-c0d5877d66a2",
  CellID->174104574],
-Cell[19752, 534, 153, 2, 35, "Categorization",ExpressionUUID->"5053e166-8912-47eb-b07b-3143e3ef90b6",
+Cell[21357, 570, 153, 2, 35, "Categorization",ExpressionUUID->"5053e166-8912-47eb-b07b-3143e3ef90b6",
  CellID->1302848004],
-Cell[19908, 538, 150, 2, 35, "Categorization",ExpressionUUID->"99b44dcc-fe0c-49c6-bb1c-013f0c0b38e2",
+Cell[21513, 574, 150, 2, 35, "Categorization",ExpressionUUID->"99b44dcc-fe0c-49c6-bb1c-013f0c0b38e2",
  CellID->1223138416],
-Cell[20061, 542, 171, 2, 35, "Categorization",ExpressionUUID->"649726ac-9a8a-483f-84d7-cf7f3d667ac8",
+Cell[21666, 578, 171, 2, 35, "Categorization",ExpressionUUID->"649726ac-9a8a-483f-84d7-cf7f3d667ac8",
  CellID->1573888628]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[20269, 549, 111, 1, 31, "KeywordsSection",ExpressionUUID->"d858f2f2-72f7-42bc-8cfe-94a5d1e19f24",
+Cell[21874, 585, 111, 1, 31, "KeywordsSection",ExpressionUUID->"d858f2f2-72f7-42bc-8cfe-94a5d1e19f24",
  CellID->1790090697],
-Cell[20383, 552, 100, 1, 70, "Keywords",ExpressionUUID->"46c8ae80-762f-46f3-a202-a932f02a90eb",
+Cell[21988, 588, 100, 1, 70, "Keywords",ExpressionUUID->"46c8ae80-762f-46f3-a202-a932f02a90eb",
  CellID->1955933656]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[20520, 558, 120, 1, 21, "TemplatesSection",ExpressionUUID->"bec92b59-c64e-4688-8b96-ee2e94efe4a3",
+Cell[22125, 594, 120, 1, 21, "TemplatesSection",ExpressionUUID->"bec92b59-c64e-4688-8b96-ee2e94efe4a3",
  CellID->1844771763],
-Cell[20643, 561, 149, 2, 70, "Template",ExpressionUUID->"9cc9c470-1ed8-463a-8d07-1e7ef1c06bab",
+Cell[22248, 597, 149, 2, 70, "Template",ExpressionUUID->"9cc9c470-1ed8-463a-8d07-1e7ef1c06bab",
  CellID->1857609002],
-Cell[20795, 565, 137, 2, 70, "Template",ExpressionUUID->"922efd23-6489-4a3f-877e-bd65f11ee439",
+Cell[22400, 601, 137, 2, 70, "Template",ExpressionUUID->"922efd23-6489-4a3f-877e-bd65f11ee439",
  CellID->717236528],
-Cell[20935, 569, 135, 2, 70, "Template",ExpressionUUID->"059c6b9d-b6b1-4b93-9e94-c642c8021267",
+Cell[22540, 605, 135, 2, 70, "Template",ExpressionUUID->"059c6b9d-b6b1-4b93-9e94-c642c8021267",
  CellID->768615485],
-Cell[21073, 573, 138, 2, 70, "Template",ExpressionUUID->"44062700-7f77-4cef-939e-cee4b8074b77",
+Cell[22678, 609, 138, 2, 70, "Template",ExpressionUUID->"44062700-7f77-4cef-939e-cee4b8074b77",
  CellID->1006319690]
 }, Closed]]
 }, Open  ]]
 }
 ]
 *)
-
-(* End of internal cache information *)
 

--- a/ChatGPTPluginKit/Documentation/English/Tutorials/InstallChatGPTPlugin.nb
+++ b/ChatGPTPluginKit/Documentation/English/Tutorials/InstallChatGPTPlugin.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    710997,      12124]
-NotebookOptionsPosition[    704313,      11977]
-NotebookOutlinePosition[    705246,      12003]
-CellTagsIndexPosition[    705203,      12000]
+NotebookDataLength[    711313,      12130]
+NotebookOptionsPosition[    704633,      11983]
+NotebookOutlinePosition[    705562,      12009]
+CellTagsIndexPosition[    705519,      12006]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -42,9 +42,9 @@ Cell[BoxData[{
    RowBox[{"<|", 
     RowBox[{"\"\<Christopher\>\"", "->", 
      RowBox[{"{", "\"\<Buy food\>\"", "}"}]}], "|>"}]}], ";"}], "\n", 
- RowBox[{"plugin", "=", 
-  RowBox[{"ChatGPTPlugin", "[", 
-   RowBox[{
+ RowBox[{"server", "=", 
+  RowBox[{"ChatGPTPluginDeploy", "@", 
+   RowBox[{"ChatGPTPlugin", "[", 
     RowBox[{"<|", "\[IndentingNewLine]", 
      RowBox[{
       RowBox[{"\"\<Name\>\"", "->", "\"\<TODOList\>\""}], ",", 
@@ -56,46 +56,51 @@ your TODOs.\>\""}], ",", "\[IndentingNewLine]",
       RowBox[{
       "\"\<Description\>\"", "->", 
        "\"\<Plugin for managing a TODO list, you can add, remove and view \
-your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",", 
-    "\[IndentingNewLine]", 
-    RowBox[{"{", "\[IndentingNewLine]", 
-     RowBox[{
-      RowBox[{"ChatGPTPluginEndpoint", "[", 
-       RowBox[{"\"\<getTodos\>\"", ",", "\"\<username\>\"", ",", 
+your TODOs.\>\""}], ",", "\[IndentingNewLine]", 
+      RowBox[{"\"\<Endpoints\>\"", "->", 
+       RowBox[{"<|", "\[IndentingNewLine]", 
         RowBox[{
-         RowBox[{"Lookup", "[", 
-          RowBox[{"todos", ",", "#username", ",", 
-           RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{"ChatGPTPluginEndpoint", "[", 
-       RowBox[{"\"\<addTodo\>\"", ",", 
-        RowBox[{"{", 
-         RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
-        RowBox[{
-         RowBox[{"(", 
-          RowBox[{
-           RowBox[{"todos", "[", "#username", "]"}], "=", 
-           RowBox[{"Append", "[", 
+         RowBox[{"\"\<getTodos\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
+           RowBox[{"\"\<username\>\"", ",", 
             RowBox[{
              RowBox[{"Lookup", "[", 
               RowBox[{"todos", ",", "#username", ",", 
-               RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], ")"}], 
-         "&"}]}], "]"}], ",", "\[IndentingNewLine]", 
-      RowBox[{"ChatGPTPluginEndpoint", "[", 
-       RowBox[{"\"\<deleteTodo\>\"", ",", 
-        RowBox[{"{", 
-         RowBox[{"\"\<username\>\"", ",", 
-          RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], ",", 
-        RowBox[{
-         RowBox[{"(", 
-          RowBox[{
-           RowBox[{"todos", "[", "#username", "]"}], "=", 
-           RowBox[{"Delete", "[", 
+               RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}]}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"\"\<addTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
+           RowBox[{
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
             RowBox[{
-             RowBox[{"todos", "[", "#username", "]"}], ",", 
-             RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], "&"}]}], 
-       "]"}]}], "\[IndentingNewLine]", "}"}]}], "\[IndentingNewLine]", 
-   "]"}]}]}], "Input",
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Append", "[", 
+                RowBox[{
+                 RowBox[{"Lookup", "[", 
+                  RowBox[{"todos", ",", "#username", ",", 
+                   RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], 
+              ")"}], "&"}]}], "]"}]}], ",", "\[IndentingNewLine]", 
+         RowBox[{"\"\<deleteTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
+           RowBox[{
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", 
+              RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], 
+            ",", 
+            RowBox[{
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Delete", "[", 
+                RowBox[{
+                 RowBox[{"todos", "[", "#username", "]"}], ",", 
+                 RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], 
+             "&"}]}], "]"}]}]}], "\[IndentingNewLine]", "|>"}]}]}], 
+     "\[IndentingNewLine]", "|>"}], "\[IndentingNewLine]", 
+    "]"}]}]}]}], "Input",
  CellChangeTimes->{{3.8892965279564943`*^9, 3.889296531899847*^9}, {
    3.8892967426239843`*^9, 3.8892967723501663`*^9}, {3.8892968593944063`*^9, 
    3.889296921140484*^9}, {3.889321382514422*^9, 3.889321408323019*^9}, {
@@ -103,7 +108,8 @@ your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",",
    3.889321910054644*^9}, {3.889325811363647*^9, 3.8893258117232656`*^9}, {
    3.88941170940053*^9, 3.889411712451518*^9}, 3.889450158192483*^9, 
    3.8894503830116034`*^9, {3.889450484885947*^9, 3.889450491289304*^9}, {
-   3.889454945124021*^9, 3.8894549453458643`*^9}},
+   3.889454945124021*^9, 3.8894549453458643`*^9}, {3.890399738197834*^9, 
+   3.890399740235277*^9}},
  CellLabel->"In[15]:=",
  CellID->643365822,ExpressionUUID->"3bf3f6f5-706a-4a3e-b5cc-9d270ae9b0f2"],
 
@@ -11976,7 +11982,7 @@ Cell["plugin", "Keywords",
 }, Open  ]]
 },
 WindowSize->{700, 770},
-WindowMargins->{{Automatic, 266}, {Automatic, 39}},
+WindowMargins->{{485, Automatic}, {Automatic, 41}},
 TaggingRules->{
  "DocuToolsSettingsInternal" -> {
    "$PacletVersion" -> "0.10.2323", "$ApplicationName" -> "Mathematica", 
@@ -11986,7 +11992,7 @@ TaggingRules->{
     "$UseNewPageDialog" -> ""}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "Wolfram/ChatGPTPluginKit"},
-FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
+FrontEndVersion->"13.3 for Mac OS X x86 (64-bit) (April 8, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "TechNotePageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"2953e474-590c-4ed0-b04b-19263a697e6e"
@@ -12011,124 +12017,122 @@ Cell[CellGroupData[{
 Cell[927, 31, 263, 3, 41, "MathCaption",ExpressionUUID->"377175c0-156d-4884-ba13-a47e50cdf64c",
  CellID->133537831],
 Cell[CellGroupData[{
-Cell[1215, 38, 3028, 69, 370, "Input",ExpressionUUID->"3bf3f6f5-706a-4a3e-b5cc-9d270ae9b0f2",
+Cell[1215, 38, 3348, 75, 351, "Input",ExpressionUUID->"3bf3f6f5-706a-4a3e-b5cc-9d270ae9b0f2",
  CellID->643365822],
-Cell[4246, 109, 20916, 407, 53, "Output",ExpressionUUID->"1b4f5360-ed26-4d40-9196-c15b67354c2e",
+Cell[4566, 115, 20916, 407, 53, "Output",ExpressionUUID->"1b4f5360-ed26-4d40-9196-c15b67354c2e",
  CellID->1349055682]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[25211, 522, 206, 2, 41, "MathCaption",ExpressionUUID->"c1a0ba99-ca2d-4935-8814-aaf2e820c14e",
+Cell[25531, 528, 206, 2, 41, "MathCaption",ExpressionUUID->"c1a0ba99-ca2d-4935-8814-aaf2e820c14e",
  CellID->234386535],
 Cell[CellGroupData[{
-Cell[25442, 528, 269, 5, 27, "Input",ExpressionUUID->"76bf32a4-9a93-49d4-9d63-f2af669e0388",
+Cell[25762, 534, 269, 5, 27, "Input",ExpressionUUID->"76bf32a4-9a93-49d4-9d63-f2af669e0388",
  CellID->174135504],
-Cell[25714, 535, 39192, 759, 53, "Output",ExpressionUUID->"dac4345e-f73e-4025-ab86-63621407a4cc",
+Cell[26034, 541, 39192, 759, 53, "Output",ExpressionUUID->"dac4345e-f73e-4025-ab86-63621407a4cc",
  CellID->1312735496]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[64955, 1300, 292, 5, 41, "MathCaption",ExpressionUUID->"06e61e4d-c453-4ac6-8993-7b0d233f6d52",
+Cell[65275, 1306, 292, 5, 41, "MathCaption",ExpressionUUID->"06e61e4d-c453-4ac6-8993-7b0d233f6d52",
  CellID->1705141266],
 Cell[CellGroupData[{
-Cell[65272, 1309, 238, 4, 27, "Input",ExpressionUUID->"14476308-f90c-4ecf-9e99-476c95b53b78",
+Cell[65592, 1315, 238, 4, 27, "Input",ExpressionUUID->"14476308-f90c-4ecf-9e99-476c95b53b78",
  CellID->1611781155],
-Cell[65513, 1315, 15736, 326, 71, "Output",ExpressionUUID->"aee12305-ce17-4667-8383-c2372f3c602c",
+Cell[65833, 1321, 15736, 326, 71, "Output",ExpressionUUID->"aee12305-ce17-4667-8383-c2372f3c602c",
  CellID->1298808834]
 }, Open  ]]
 }, Open  ]],
-Cell[81276, 1645, 249, 5, 25, "Text",ExpressionUUID->"a1da58b5-9147-49f7-b512-325a4b52506f",
+Cell[81596, 1651, 249, 5, 25, "Text",ExpressionUUID->"a1da58b5-9147-49f7-b512-325a4b52506f",
  CellID->1767073656],
 Cell[CellGroupData[{
-Cell[81550, 1654, 213, 2, 41, "MathCaption",ExpressionUUID->"cc592940-560c-457d-bf2b-da9ea2474353",
+Cell[81870, 1660, 213, 2, 41, "MathCaption",ExpressionUUID->"cc592940-560c-457d-bf2b-da9ea2474353",
  CellID->1621404836],
-Cell[81766, 1658, 59366, 979, 486, "Input",ExpressionUUID->"9d5d6057-3369-4605-beb1-0316b9db5ed3",
+Cell[82086, 1664, 59366, 979, 486, "Input",ExpressionUUID->"9d5d6057-3369-4605-beb1-0316b9db5ed3",
  CellID->207987529]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[141169, 2642, 194, 2, 41, "MathCaption",ExpressionUUID->"ab4310c5-d979-49f0-a734-b4ec7319c7e4",
+Cell[141489, 2648, 194, 2, 41, "MathCaption",ExpressionUUID->"ab4310c5-d979-49f0-a734-b4ec7319c7e4",
  CellID->322480646],
-Cell[141366, 2646, 65249, 1075, 481, "Input",ExpressionUUID->"8e339a0a-3ac3-4826-8290-8d2178545eab",
+Cell[141686, 2652, 65249, 1075, 481, "Input",ExpressionUUID->"8e339a0a-3ac3-4826-8290-8d2178545eab",
  CellID->190283010]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[206652, 3726, 199, 2, 41, "MathCaption",ExpressionUUID->"7773af25-b4ba-437c-b174-90c2d5e314a5",
+Cell[206972, 3732, 199, 2, 41, "MathCaption",ExpressionUUID->"7773af25-b4ba-437c-b174-90c2d5e314a5",
  CellID->2002330219],
-Cell[206854, 3730, 255460, 4193, 399, "Input",ExpressionUUID->"c63f3d9f-9d30-4f60-8236-438f3dd4242f",
+Cell[207174, 3736, 255460, 4193, 399, "Input",ExpressionUUID->"c63f3d9f-9d30-4f60-8236-438f3dd4242f",
  CellID->2064259148]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[462351, 7928, 613, 13, 62, "MathCaption",ExpressionUUID->"a7376cdb-e1f3-4ba1-a1fc-4f2491de54d2",
+Cell[462671, 7934, 613, 13, 62, "MathCaption",ExpressionUUID->"a7376cdb-e1f3-4ba1-a1fc-4f2491de54d2",
  CellID->2030217450],
-Cell[462967, 7943, 63287, 1043, 266, "Input",ExpressionUUID->"2be9780e-f36c-423e-9a0c-1851d584398a",
+Cell[463287, 7949, 63287, 1043, 266, "Input",ExpressionUUID->"2be9780e-f36c-423e-9a0c-1851d584398a",
  CellID->1981688222]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[526291, 8991, 246, 4, 41, "MathCaption",ExpressionUUID->"c9261ebf-86dc-432b-924d-b008ca862d2c",
+Cell[526611, 8997, 246, 4, 41, "MathCaption",ExpressionUUID->"c9261ebf-86dc-432b-924d-b008ca862d2c",
  CellID->2009659002],
-Cell[526540, 8997, 64917, 1070, 318, "Input",ExpressionUUID->"410f6101-b2a6-454a-a215-fbbca797ba81",
+Cell[526860, 9003, 64917, 1070, 318, "Input",ExpressionUUID->"410f6101-b2a6-454a-a215-fbbca797ba81",
  CellID->687012226]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[591494, 10072, 309, 6, 41, "MathCaption",ExpressionUUID->"4ec5ca40-6f9f-4be3-a7cc-c1dbcae59649",
+Cell[591814, 10078, 309, 6, 41, "MathCaption",ExpressionUUID->"4ec5ca40-6f9f-4be3-a7cc-c1dbcae59649",
  CellID->145350052],
-Cell[591806, 10080, 108966, 1792, 524, "Input",ExpressionUUID->"7b948851-2ef3-4d15-9b78-3d278f42652c",
+Cell[592126, 10086, 108966, 1792, 524, "Input",ExpressionUUID->"7b948851-2ef3-4d15-9b78-3d278f42652c",
  CellID->454881810]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[700809, 11877, 191, 2, 41, "MathCaption",ExpressionUUID->"a2045d2f-b149-4d2a-8eb4-6096789c3c16",
+Cell[701129, 11883, 191, 2, 41, "MathCaption",ExpressionUUID->"a2045d2f-b149-4d2a-8eb4-6096789c3c16",
  CellID->679621146],
-Cell[701003, 11881, 237, 4, 27, "Input",ExpressionUUID->"ae37eadf-345f-429a-adc5-5005048cc9db",
+Cell[701323, 11887, 237, 4, 27, "Input",ExpressionUUID->"ae37eadf-345f-429a-adc5-5005048cc9db",
  CellID->840922330]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[701277, 11890, 192, 2, 74, "TutorialMoreAboutSection",ExpressionUUID->"5448be5a-a447-442c-ba11-b54f69215bc9",
+Cell[701597, 11896, 192, 2, 74, "TutorialMoreAboutSection",ExpressionUUID->"5448be5a-a447-442c-ba11-b54f69215bc9",
  CellID->1756600598],
-Cell[701472, 11894, 109, 1, 24, "TutorialMoreAbout",ExpressionUUID->"723ae501-7ee2-4475-b46c-321678259736",
+Cell[701792, 11900, 109, 1, 24, "TutorialMoreAbout",ExpressionUUID->"723ae501-7ee2-4475-b46c-321678259736",
  CellID->1728555277]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[701618, 11900, 128, 1, 74, "RelatedTutorialsSection",ExpressionUUID->"e5548a78-f6af-405f-a815-6247545499cc",
+Cell[701938, 11906, 128, 1, 74, "RelatedTutorialsSection",ExpressionUUID->"e5548a78-f6af-405f-a815-6247545499cc",
  CellID->669763923],
-Cell[701749, 11903, 108, 1, 24, "RelatedTutorials",ExpressionUUID->"8fb578d1-e6e8-4915-8b65-a906ae5b5b67",
+Cell[702069, 11909, 108, 1, 24, "RelatedTutorials",ExpressionUUID->"8fb578d1-e6e8-4915-8b65-a906ae5b5b67",
  CellID->1760459934]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[701906, 11910, 109, 1, 72, "MetadataSection",ExpressionUUID->"fadd9a7f-b7a5-43d7-934b-673ab88e8c2d",
+Cell[702226, 11916, 109, 1, 72, "MetadataSection",ExpressionUUID->"fadd9a7f-b7a5-43d7-934b-673ab88e8c2d",
  CellID->20422372],
-Cell[702018, 11913, 477, 12, 26, "History",ExpressionUUID->"43014bb4-705d-4aac-bef5-044c5e5bd603",
+Cell[702338, 11919, 477, 12, 26, "History",ExpressionUUID->"43014bb4-705d-4aac-bef5-044c5e5bd603",
  CellID->1788906331],
 Cell[CellGroupData[{
-Cell[702520, 11929, 123, 1, 21, "CategorizationSection",ExpressionUUID->"039e21ad-391a-46f4-912d-461fe7c9bf70",
+Cell[702840, 11935, 123, 1, 21, "CategorizationSection",ExpressionUUID->"039e21ad-391a-46f4-912d-461fe7c9bf70",
  CellID->1377647117],
-Cell[702646, 11932, 138, 2, 34, "Categorization",ExpressionUUID->"3e71b095-7046-40d9-b04f-e107c4b52954",
+Cell[702966, 11938, 138, 2, 34, "Categorization",ExpressionUUID->"3e71b095-7046-40d9-b04f-e107c4b52954",
  CellID->2093897112],
-Cell[702787, 11936, 153, 2, 34, "Categorization",ExpressionUUID->"fc7ea2e1-8109-4a6b-bd60-a44362c10d8c",
+Cell[703107, 11942, 153, 2, 34, "Categorization",ExpressionUUID->"fc7ea2e1-8109-4a6b-bd60-a44362c10d8c",
  CellID->1314237995],
-Cell[702943, 11940, 150, 2, 34, "Categorization",ExpressionUUID->"402f5467-bc7f-439e-8f14-d7f010c6d31b",
+Cell[703263, 11946, 150, 2, 34, "Categorization",ExpressionUUID->"402f5467-bc7f-439e-8f14-d7f010c6d31b",
  CellID->1528672570],
-Cell[703096, 11944, 177, 3, 34, "Categorization",ExpressionUUID->"995dfe2c-ed23-4d60-a469-4af999d9b57d",
+Cell[703416, 11950, 177, 3, 34, "Categorization",ExpressionUUID->"995dfe2c-ed23-4d60-a469-4af999d9b57d",
  CellID->2053014929]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[703310, 11952, 111, 1, 31, "KeywordsSection",ExpressionUUID->"53bd345b-7fff-402a-a3b0-5151b3aa29e4",
+Cell[703630, 11958, 111, 1, 31, "KeywordsSection",ExpressionUUID->"53bd345b-7fff-402a-a3b0-5151b3aa29e4",
  CellID->1402155354],
-Cell[703424, 11955, 169, 2, 70, "Keywords",ExpressionUUID->"d5a088c5-b17a-483e-b07b-126f00ff7f27",
+Cell[703744, 11961, 169, 2, 70, "Keywords",ExpressionUUID->"d5a088c5-b17a-483e-b07b-126f00ff7f27",
  CellID->1686976147],
-Cell[703596, 11959, 168, 2, 70, "Keywords",ExpressionUUID->"8eb815ac-2b32-400a-9bac-7397d719066c",
+Cell[703916, 11965, 168, 2, 70, "Keywords",ExpressionUUID->"8eb815ac-2b32-400a-9bac-7397d719066c",
  CellID->477878083],
-Cell[703767, 11963, 169, 2, 70, "Keywords",ExpressionUUID->"ef995393-1c28-456d-b583-70a91de913a9",
+Cell[704087, 11969, 169, 2, 70, "Keywords",ExpressionUUID->"ef995393-1c28-456d-b583-70a91de913a9",
  CellID->1373549314],
-Cell[703939, 11967, 176, 2, 70, "Keywords",ExpressionUUID->"f17acb62-90d3-4aaf-89ba-112409329181",
+Cell[704259, 11973, 176, 2, 70, "Keywords",ExpressionUUID->"f17acb62-90d3-4aaf-89ba-112409329181",
  CellID->2011502077],
-Cell[704118, 11971, 167, 2, 70, "Keywords",ExpressionUUID->"2426866d-ce68-4828-a2b4-36f1fb4c225f",
+Cell[704438, 11977, 167, 2, 70, "Keywords",ExpressionUUID->"2426866d-ce68-4828-a2b4-36f1fb4c225f",
  CellID->104461319]
 }, Closed]]
 }, Open  ]]
 }
 ]
 *)
-
-(* End of internal cache information *)
 

--- a/ChatGPTPluginKit/Kernel/Deploy.wl
+++ b/ChatGPTPluginKit/Kernel/Deploy.wl
@@ -38,16 +38,13 @@ iChatGPTPluginDeploy[{plugin_ChatGPTPlugin, port_}, opts_] :=
 		]&
 	]
 
+iChatGPTPluginDeploy[{spec_, port_}, opts_] :=
+	Enclose[
+		iChatGPTPluginDeploy[{Confirm@ChatGPTPlugin[spec], port}, opts],
+		"InheritedFailure"
+	]
 
-iChatGPTPluginDeploy[{plugin_, loc_}, opts_] :=
-	Failure["InvalidPlugin", <|
-		"MessageTemplate" -> "Expected a ChatGPTPlugin object but found `1` instead.",
-		"MessageParamters" -> {plugin},
-		"PluginSpecification" -> plugin
-	|>]
-	
-
-iChatGPTPluginDeploy[{plugin_ChatGPTPlugin}, opts_] :=
+iChatGPTPluginDeploy[{plugin_}, opts_] :=
 	iChatGPTPluginDeploy[{plugin, $ChatGPTPluginPort}, opts]
 
 

--- a/ChatGPTPluginKit/Kernel/Endpoint.wl
+++ b/ChatGPTPluginKit/Kernel/Endpoint.wl
@@ -28,7 +28,8 @@ argumentsChatGPTPluginEndpointQ[
 					"Required" -> _
 				}])...
 		},
-		"Function" -> _
+		"Function" -> _,
+		"APIFunctionOptions" -> _
 	}]?AssociationQ,
 	{OptionsPattern[]}
 ] :=
@@ -51,8 +52,7 @@ icreateChatGPTPluginEndpoint[{opSpec_, params_, f_}, opts_] :=
 				<|
 					"Parameters" -> Confirm@normalizeParamsList[params],
 					"Function" -> f
-				|>,
-				f
+				|>
 			],
 			opts
 		],
@@ -95,18 +95,89 @@ normalizeParamProps[props_?AssociationQ] :=
 	}, Last]
 
 
-(* Association constructor *)
+(* Association constructors *)
 
-icreateChatGPTPluginEndpoint[{opName_, body_}, opts_] :=
+icreateChatGPTPluginEndpoint[{opName_, assoc_}, opts_] :=
 	Enclose[
-		ChatGPTPluginEndpoint[
-			{opName},
-			normalizeParamsList[params],
-			f,
-			opts
+		With[{
+				prompt = Lookup[assoc, "Prompt", Missing["NotSpecified"]],
+				apiFunc = Lookup[assoc, "APIFunction", ConfirmAssert[False, missingAPIFunctionFailure[assoc]]]
+			},
+			ChatGPTPluginEndpoint[
+				Join[
+					<|
+						"OperationID" -> ConfirmBy[opName, StringQ, invalidNameFailure[opName]],
+						"Prompt" -> ConfirmMatch[prompt, _?StringQ | _Missing, invalidPromptFailure[prompt]]
+					|>,
+					Confirm@normalizeAPIFunction[apiFunc]
+				],
+				opts
+			]
 		],
 		"InheritedFailure"
 	]
+
+icreateChatGPTPluginEndpoint[{opName_, apiFunc_APIFunction}, opts_] :=
+	icreateChatGPTPluginEndpoint[{opName, <|"APIFunction" -> apiFunc|>}, opts]
+
+
+normalizeAPIFunction[APIFunction[args___]] :=
+	With[{res = ArgumentsOptions[APIFunction[args], {1,3}]},
+		If[!FailureQ[res],
+			inormalizeAPIFunction@@res,
+			Failure["InvalidAPIFunction", <|
+				"MessageTemplate" -> "Expected a valid APIFunction but found `1` instead.",
+				"MessageParameters" -> {api},
+				"Name" -> api
+			|>]
+		]
+	]
+
+inormalizeAPIFunction[{params_, f_, fmt_}, opts_] :=
+	Enclose[
+		<|
+			"Parameters" -> Confirm@normalizeParamsList[params],
+			"Function" -> f,
+			"OutputFormat" -> fmt,
+			"APIFunctionOptions" -> opts
+		|>,
+		"InheritedFailure"
+	]
+
+inormalizeAPIFunction[{params_, f_}, opts_] :=
+	Enclose[
+		<|
+			"Parameters" -> Confirm@normalizeParamsList[params],
+			"Function" -> f,
+			"APIFunctionOptions" -> opts
+		|>,
+		"InheritedFailure"
+	]
+
+inormalizeAPIFunction[{params_}, opts_] :=
+	inormalizeAPIFunction[{params, Identity}, opts]
+
+
+invalidNameFailure[name_] :=
+	Failure["InvalidEndpointName", <|
+		"MessageTemplate" -> "Expected an endpoint name as a string but found `1` instead.",
+		"MessageParameters" -> {name},
+		"Name" -> name
+	|>]
+
+invalidPromptFailure[prompt_] :=
+	Failure["InvalidEndpointPrompt", <|
+		"MessageTemplate" -> "Expected an endpoint prompt as a string or Missing but found `1` instead.",
+		"MessageParameters" -> {prompt},
+		"Prompt" -> prompt
+	|>]
+
+missingAPIFunctionFailure[assoc_] :=
+	Failure["MissingAPIFunction", <|
+		"MessageTemplate" -> "Required an APIFunction in endpoint, but only found `1`.",
+		"MessageParameters" -> {assoc},
+		"Data" -> assoc
+	|>]
 
 
 
@@ -115,10 +186,11 @@ icreateChatGPTPluginEndpoint[{opName_, body_}, opts_] :=
 HoldPattern[ChatGPTPluginEndpoint][data_, opts_]["Data"] := data
 HoldPattern[ChatGPTPluginEndpoint][data_, opts_]["Options"] := opts
 
-endpoint_ChatGPTPluginEndpoint["OperationID"] := endpoint["data"]["OperationID"]
-endpoint_ChatGPTPluginEndpoint["Prompt"] := endpoint["data"]["Prompt"]
-endpoint_ChatGPTPluginEndpoint["Parameters"] := endpoint["data"]["Parameters"]
-endpoint_ChatGPTPluginEndpoint["Function"] := endpoint["data"]["Function"]
+endpoint_ChatGPTPluginEndpoint["OperationID"] := endpoint["Data"]["OperationID"]
+endpoint_ChatGPTPluginEndpoint["Prompt"] := endpoint["Data"]["Prompt"]
+endpoint_ChatGPTPluginEndpoint["Parameters"] := endpoint["Data"]["Parameters"]
+endpoint_ChatGPTPluginEndpoint["Function"] := endpoint["Data"]["Function"]
+endpoint_ChatGPTPluginEndpoint["APIFunctionOptions"] := endpoint["Data"]["APIFunctionOptions"]
 
 endpoint_ChatGPTPluginEndpoint["OpenAPIJSON"] := endpointAPIJSON[endpoint]
 endpoint_ChatGPTPluginEndpoint["APIFunction"] := endpointAPIFunction[endpoint]
@@ -153,7 +225,19 @@ endpointParamAPIJSON[name_ -> KeyValuePattern[{"Help" -> prompt_, "Required" -> 
 (* Because of CORS, ChatGPT makes an OPTIONS request before its POST request. This must return the right headers, but
 it shouldn't run the function body. *)
 endpointAPIFunction[endpoint_ChatGPTPluginEndpoint] :=
-	APIFunction[removeHelp@endpoint["Parameters"], If[HTTPRequestData["Method"] === "OPTIONS", "", endpoint["Function"][#]]&]
+	If[KeyExistsQ[endpoint["Data"], "OutputFormat"],
+		APIFunction[
+			removeHelp@endpoint["Parameters"],
+			With[{funcBody = endpoint["Function"]}, If[HTTPRequestData["Method"] === "OPTIONS", "", funcBody[#]]&],
+			endpoint["Data"]["OutputFormat"],
+			endpoint["APIFunctionOptions"]
+		],
+		APIFunction[
+			removeHelp@endpoint["Parameters"],
+			With[{funcBody = endpoint["Function"]}, If[HTTPRequestData["Method"] === "OPTIONS", "", funcBody[#]]&],
+			endpoint["APIFunctionOptions"]
+		]
+	]
 
 
 (* TODO: Temporary workaround for bug #434606 *)

--- a/ChatGPTPluginKit/Kernel/Plugin.wl
+++ b/ChatGPTPluginKit/Kernel/Plugin.wl
@@ -73,7 +73,7 @@ normalizeMetadata[expr_] :=
 normalizeEndpoints[endpoint_ChatGPTPluginEndpoint] := {endpoint}
 normalizeEndpoints[endpoints: {__ChatGPTPluginEndpoint}] := endpoints
 normalizeEndpoints[name_ -> data_] := normalizeEndpoints[ChatGPTPluginEndpoint[name, data]]
-normalizeEndpoints[endpoints: KeyValuePattern[{}]] := normalizeEndpoints[KeyValueMap[ChatGPTPluginEndpoint, endpoints]]
+normalizeEndpoints[endpoints: KeyValuePattern[{}] /; Length[endpoints] > 0] := normalizeEndpoints[KeyValueMap[ChatGPTPluginEndpoint, Association@endpoints]]
 normalizeEndpoints[expr_] :=
 	Failure["InvalidEndpointsSpecification", <|
 		"MessageTemplate" -> "Expected a single ChatGPTPluginEndpoint, a list with at least one ChatGPTPluginEndpoint, or an association specifying ChatGPTEndpoints, but found `1` instead.",

--- a/ChatGPTPluginKit/Kernel/Plugin.wl
+++ b/ChatGPTPluginKit/Kernel/Plugin.wl
@@ -21,9 +21,9 @@ argumentsChatGPTPluginQ[
 	KeyValuePattern[{
 		"Name" -> _,
 		"Description" -> _,
-		"Prompt" -> _
+		"Prompt" -> _,
+		"Endpoints" -> {__ChatGPTPluginEndpoint}
 	}],
-	{__ChatGPTPluginEndpoint},
 	{OptionsPattern[]}
 ] := True
 
@@ -39,8 +39,10 @@ createChatGPTPlugin[args___] :=
 icreateChatGPTPlugin[{metadata_, endpoints_}, opts_] :=
 	Enclose[
 		ChatGPTPlugin[
-			Confirm@normalizeMetadata[metadata],
-			Confirm@normalizeEndpoints[endpoints],
+			Join[
+				Confirm@normalizeMetadata[metadata],
+				<|"Endpoints" -> Confirm@normalizeEndpoints[endpoints]|>
+			],
 			opts
 		],
 		"InheritedFailure"
@@ -85,8 +87,10 @@ normalizeEndpoints[expr_] :=
 icreateChatGPTPlugin[{assoc:KeyValuePattern[{}]}, opts_] :=
 	Enclose[
 		ChatGPTPlugin[
-			Confirm@normalizeMetadata[assoc],
-			Confirm@normalizeEndpoints[Lookup[assoc, "Endpoints", {}]],
+			Join[
+				Confirm@normalizeMetadata[assoc],
+				<|"Endpoints" -> Confirm@normalizeEndpoints[Lookup[assoc, "Endpoints", {}]]|>
+			],
 			opts
 		],
 		"InheritedFailure"
@@ -104,13 +108,13 @@ icreateChatGPTPlugin[{spec_}, opts_] :=
 
 (* Accessors *)
 
-HoldPattern[ChatGPTPlugin][metadata_, endpoints_, opts_]["Metadata"] := metadata
-HoldPattern[ChatGPTPlugin][metadata_, endpoints_, opts_]["Endpoints"] := endpoints
-HoldPattern[ChatGPTPlugin][metadata_, endpoints_, opts_]["Options"] := opts
+HoldPattern[ChatGPTPlugin][data_, opts_]["Data"] := data
+HoldPattern[ChatGPTPlugin][data_, opts_]["Options"] := opts
 
-plugin_ChatGPTPlugin["Name"] := Lookup[plugin["Metadata"], "Name"]
-plugin_ChatGPTPlugin["Description"] := Lookup[plugin["Metadata"], "Description"]
-plugin_ChatGPTPlugin["Prompt"] := Lookup[plugin["Metadata"], "Prompt"]
+plugin_ChatGPTPlugin["Name"] := Lookup[plugin["Data"], "Name"]
+plugin_ChatGPTPlugin["Description"] := Lookup[plugin["Data"], "Description"]
+plugin_ChatGPTPlugin["Prompt"] := Lookup[plugin["Data"], "Prompt"]
+plugin_ChatGPTPlugin["Endpoints"] := Lookup[plugin["Data"], "Endpoints"]
 plugin_ChatGPTPlugin["OpenAPIJSON", port_] := pluginAPIJSON[plugin, port]
 plugin_ChatGPTPlugin["OpenAPIJSON"] := plugin["OpenAPIJSON", $ChatGPTPluginPort]
 plugin_ChatGPTPlugin["ManifestJSON", port_] := pluginManifestJSON[plugin, port]

--- a/ChatGPTPluginKit/ResourceDefinition.nb
+++ b/ChatGPTPluginKit/ResourceDefinition.nb
@@ -40,9 +40,8 @@ Cell[CellGroupData[{
 
 Cell["", "FileManagerTopSpacer",
  CellGroupingRules->{"SectionGrouping", 99},
- TaggingRules->{},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->637527297,ExpressionUUID->"9d8d859b-c529-49eb-87d7-3293b8fd8dd2"],
+ CellID->637527297,ExpressionUUID->"cbc6558e-be1d-47c2-8c28-523494008d90"],
 
 Cell[CellGroupData[{
 
@@ -71,18 +70,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Documentation"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"14f3b472-75f6-4aec-86bb-57f273888a66"]], \
+   "Text"}]],ExpressionUUID->"f7039686-61b5-4bed-b856-66aceb0ae898"]], \
 "FileManagerDirectory",
  CellMargins->{{Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDocumentationIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1125365796,ExpressionUUID->"eaa18071-3608-4f14-adaa-430a72b69950"],
+ CellID->1125365796,ExpressionUUID->"d14f8411-07ee-4975-8f8e-7112998de1f2"],
 
 Cell[CellGroupData[{
 
@@ -111,18 +109,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Documentation", "English"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"7ba128d4-9818-4494-a643-0f5dc0c5ffb8"]], \
+   "Text"}]],ExpressionUUID->"047ce6fd-a70f-415a-af64-4c97290a06bf"]], \
 "FileManagerDirectory",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDirectoryIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1134454243,ExpressionUUID->"cb6b0fcb-5203-4147-a247-facdf6804905"],
+ CellID->1134454243,ExpressionUUID->"f75f1a32-a31a-4e49-8f31-0b538dc9d86f"],
 
 Cell[CellGroupData[{
 
@@ -150,18 +147,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Documentation", "English", "Guides"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"54e3450f-221f-41a2-b59e-756c9de5107b"]], \
+   "Text"}]],ExpressionUUID->"d2669dc2-9348-45da-8108-95eb222ed1ef"]], \
 "FileManagerDirectory",
  CellMargins->{{46 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 120},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDirectoryIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1412644035,ExpressionUUID->"38ccb604-dc93-45cd-b415-2c6a15a4baed"],
+ CellID->1412644035,ExpressionUUID->"de1ef5bd-ab62-43cd-bd64-f048b7ba637d"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -180,15 +176,14 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{69 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 130},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->655010840,ExpressionUUID->"6a97970c-ab8a-49fa-a9f6-5d35e871f246"]
-}, Closed]],
+ CellID->655010840,ExpressionUUID->"a25a1137-56ff-41a3-9711-3be60522f062"]
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -217,18 +212,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Documentation", "English", "ReferencePages"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"9dbbe3f5-1457-46f9-8785-ed19765ca122"]], \
+   "Text"}]],ExpressionUUID->"696f2b8c-cf54-4a38-abce-fd479b58cffb"]], \
 "FileManagerDirectory",
  CellMargins->{{46 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 120},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDirectoryIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1712698778,ExpressionUUID->"9d5665f0-5a9d-496f-a6ef-c2dc60262195"],
+ CellID->1712698778,ExpressionUUID->"94faa354-6737-4f24-bbde-36580649e98a"],
 
 Cell[CellGroupData[{
 
@@ -258,18 +252,17 @@ Cell[TextData[Cell[BoxData[
     "Symbols"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"3d6afe3a-4901-438a-a87e-986f383179f4"]], \
+   "Text"}]],ExpressionUUID->"04bfc69f-d701-48b6-a85d-7db12bcd9ae4"]], \
 "FileManagerDirectory",
  CellMargins->{{69 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 130},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDirectoryIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->457557458,ExpressionUUID->"adcb96ab-6fbd-4c06-a71f-dc7efc2e0919"],
+ CellID->457557458,ExpressionUUID->"c7c0a12b-0b3b-4d7d-9c2b-c948d8b05bbb"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -288,14 +281,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{92 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 140},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->29256699,ExpressionUUID->"bfcfa449-730b-4f85-b729-f30ca0a8ddde"],
+ CellID->29256699,ExpressionUUID->"4211056b-06cb-4031-bb48-b09312ad58d7"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -314,14 +306,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{92 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 140},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->2091068577,ExpressionUUID->"88716c66-fb93-4904-a183-6df0f514dac2"],
+ CellID->2091068577,ExpressionUUID->"5b6d6f89-62ce-48b1-80a9-5bb0a60debf7"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -340,14 +331,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{92 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 140},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1019690484,ExpressionUUID->"2e0f3ba8-409f-489c-919e-59a4213b3993"],
+ CellID->1019690484,ExpressionUUID->"76512472-1c86-4b22-809e-c8b1a9949dc6"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -366,14 +356,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{92 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 140},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1018461528,ExpressionUUID->"9791f261-8857-4103-8c45-2d52746755b4"]
+ CellID->1018461528,ExpressionUUID->"0676f02c-82d2-4c58-8da7-b0f5decab6e7"]
 }, Open  ]]
 }, Open  ]],
 
@@ -404,18 +393,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Documentation", "English", "Tutorials"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"9ade7182-55d3-472e-b904-206a8ac87dcb"]], \
+   "Text"}]],ExpressionUUID->"af03168c-6b56-4501-a55e-fd0791bc9dce"]], \
 "FileManagerDirectory",
  CellMargins->{{46 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 120},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerDirectoryIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1838234506,ExpressionUUID->"635f408d-0e6b-4e62-8098-b6d5fa48c9b4"],
+ CellID->1838234506,ExpressionUUID->"1304bc6b-af76-4f3e-9c72-1c1c36a5ea83"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -434,15 +422,14 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{69 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 130},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1507596600,ExpressionUUID->"67f68968-4f39-486b-88ed-7e1e3236f4a3"]
-}, Closed]]
+ CellID->1507596600,ExpressionUUID->"0904852d-fc9e-4ef6-bc62-691a9f4a3eec"]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]],
 
@@ -472,18 +459,17 @@ Cell[TextData[Cell[BoxData[
     NotebookDirectory[], "Kernel"}],
   BoxID -> "FileTreePath",
   BaseStyle->{
-   "Text"}]],ExpressionUUID->"aec84fdc-aec4-48a6-b596-4977dff11a5a"]], \
+   "Text"}]],ExpressionUUID->"35664230-c5a4-41dc-8094-7a40aa035a62"]], \
 "FileManagerDirectory",
  CellMargins->{{Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerKernelIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->16505247,ExpressionUUID->"19f3480e-9ac2-4585-8cf8-b34e72295556"],
+ CellID->16505247,ExpressionUUID->"37d730c6-ed84-4167-ac16-ecaf1d29a9b2"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -500,14 +486,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerWLIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->378295866,ExpressionUUID->"bb6f0368-df4b-4507-b322-d3d769232f22"],
+ CellID->378295866,ExpressionUUID->"87ef2794-cd0d-4c9f-a0b3-f62d667b2912"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -524,14 +509,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerWLIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1467024742,ExpressionUUID->"d78fe7f0-8bfa-42ed-a0f3-c40ed9c14506"],
+ CellID->1467024742,ExpressionUUID->"1cc0408c-0e7b-4eb4-9c94-d0e95400f756"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -548,14 +532,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerWLIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1025087587,ExpressionUUID->"f6420737-715f-4324-8f4f-c7035751acd3"],
+ CellID->1025087587,ExpressionUUID->"b4cbdc77-2ab3-4730-bff7-2ce3e82b0b28"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -572,14 +555,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerWLIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1533258475,ExpressionUUID->"3ede0d2a-72e7-4757-b170-749277caa77b"],
+ CellID->1533258475,ExpressionUUID->"4081eed8-1687-4131-9c19-8d0de66944c2"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -596,14 +578,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{23 + Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 110},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerWLIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1818908972,ExpressionUUID->"21a8a90b-29c9-415a-9dd9-7694562a56a7"]
+ CellID->1818908972,ExpressionUUID->"a1be9e6f-b5c8-492d-9c8a-06e9b5b30862"]
 }, Closed]],
 
 Cell[BoxData[
@@ -621,14 +602,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerUnknownIconTemplate"]], Background -> None],
      Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->973377359,ExpressionUUID->"f3b64376-6bbf-4887-ac4d-eebe8f36a7cb"],
+ CellID->973377359,ExpressionUUID->"de2efdae-83b4-4a49-be34-7f5c65f5cf2c"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -645,14 +625,13 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerPacletInfoIconTemplate"]], Background -> 
      None], Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->22849867,ExpressionUUID->"1b4441b1-4a56-4986-88bd-76c847b9a93d"],
+ CellID->22849867,ExpressionUUID->"483aa24d-cb81-4e97-b971-fda8ac4aa5bc"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -669,20 +648,18 @@ Cell[BoxData[
   BaseStyle->{"Text"}]], "FileManagerFile",
  CellMargins->{{Inherited, Inherited}, {Inherited, Inherited}},
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellFrameLabels->{{
     Cell[
      BoxData[
       TemplateBox[{}, "FileManagerNBIconTemplate"]], Background -> None], 
     Inherited}, {Inherited, Inherited}},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->1785625503,ExpressionUUID->"393f57b5-3f42-44a7-a7c7-7d0ee23a7df9"],
+ CellID->1785625503,ExpressionUUID->"a08188a2-bec6-4a71-833b-2ded4e5a707d"],
 
 Cell["", "FileManagerBottomSpacer",
  CellGroupingRules->{"SectionGrouping", 100},
- TaggingRules->{},
  CellTags->{"FileManagerCell", "FileManager-PacletFiles"},
- CellID->2071345743,ExpressionUUID->"285f7b00-9b31-4d24-97a4-e29943083ddf"]
+ CellID->2071345743,ExpressionUUID->"c00fa8c6-9391-4bb2-afeb-a01416104cc0"]
 }, Open  ]]
 }, Open  ]],
 
@@ -1058,7 +1035,7 @@ Cell[BoxData[
    RowBox[{"NotebookDirectory", "[", "]"}], "]"}], ";"}]], "Input", "Excluded",
  TaggingRules->{},
  InitializationCell->True,
- CellLabel->"In[8]:=",
+ CellLabel->"In[3]:=",
  CellID->996717066,ExpressionUUID->"0dfb8c8c-69d7-4458-b87f-0afef3448adb"],
 
 Cell[BoxData[
@@ -1068,7 +1045,7 @@ Cell[BoxData[
  TaggingRules->{},
  InitializationCell->True,
  CellChangeTimes->{{3.8903238546959047`*^9, 3.890323857442161*^9}},
- CellLabel->"In[7]:=",
+ CellLabel->"In[2]:=",
  CellID->172764492,ExpressionUUID->"c4d8711f-5458-4c3b-9b42-32202ad64646"]
 }, Open  ]],
 
@@ -1078,252 +1055,31 @@ Cell["Basic Examples", "Subsection",
  TaggingRules->{},
  CellID->462042388,ExpressionUUID->"c537a1ea-d108-4185-a64f-7de410801926"],
 
-Cell["Define a simple plugin:", "Text",
- TaggingRules->{},
- CellChangeTimes->{{3.8894558710214233`*^9, 3.88945587778251*^9}},
- CellTags->"DefaultContent",
- CellID->319073343,ExpressionUUID->"630d3da1-4690-4d31-8540-567d323d940b"],
-
-Cell[CellGroupData[{
-
-Cell[BoxData[
- RowBox[{"plugin", "=", 
-  RowBox[{"ChatGPTPlugin", "[", 
-   RowBox[{
-    RowBox[{"<|", "\[IndentingNewLine]", 
-     RowBox[{
-      RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{"\"\<Prompt\>\"", "->", "\"\<\>\""}], ",", 
-      "\[IndentingNewLine]", 
-      RowBox[{
-      "\"\<Description\>\"", "->", 
-       "\"\<Get the populations of cities.\>\""}]}], "\[IndentingNewLine]", 
-     "|>"}], ",", "\[IndentingNewLine]", 
-    RowBox[{"ChatGPTPluginEndpoint", "[", 
-     RowBox[{"\"\<getCityPopulation\>\"", ",", 
-      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
-      RowBox[{
-       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
-   "\[IndentingNewLine]", "]"}]}]], "Input",
- TaggingRules->{},
- CellChangeTimes->{3.889455879305572*^9},
- CellTags->"DefaultContent",
- CellLabel->"In[9]:=",
- CellID->593829399,ExpressionUUID->"080c0864-db2c-4565-b838-e8aaa2dd754e"],
-
-Cell[BoxData[
- InterpretationBox[
-  RowBox[{
-   TagBox["ChatGPTPlugin",
-    "SummaryHead"], "[", 
-   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-    
-    TemplateBox[{
-      PaneSelectorBox[{False -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"CityPopulationFinder\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                 "\"Get the populations of cities.\"", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  TagBox[
-                   GridBox[{{
-                    InterpretationBox[
-                    RowBox[{
-                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
-                    
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxOpener"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxCloser"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    GridBox[{{
-                    RowBox[{
-                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["\"getCityPopulation\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox[
-                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
-                    "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                    
-                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{
-                    "getCityPopulation", 
-                    Missing["NotSpecified"]}, {
-                    "city" -> <|
-                    "Interpreter" -> "City", "Help" -> 
-                    Missing["NotSpecified"], "Required" -> True|>}, Slot[
-                    "city"]["Population"]& , {}], Selectable -> False, 
-                    Editable -> False, SelectWithContents -> True]}}, 
-                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
-                    DefaultBaseStyle -> "Column", 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-                   "Column"], "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["\"\"", "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
-       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
-     "SummaryPanel"],
-    DynamicModuleValues:>{}], "]"}],
-  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
-   "Name" -> "CityPopulationFinder", "Description" -> 
-    "Get the populations of cities.", "Prompt" -> ""|>, {
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[{"getCityPopulation", 
-      Missing["NotSpecified"]}, {
-     "city" -> <|
-       "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], "Required" -> 
-        True|>}, Slot["city"]["Population"]& , {}]}, {}],
-  Editable->False,
-  SelectWithContents->True,
-  Selectable->False]], "Output",
- TaggingRules->{},
- CellChangeTimes->{3.889455879809272*^9, 3.890324050677603*^9},
- CellTags->"DefaultContent",
- CellLabel->"Out[9]=",
- CellID->460945175,ExpressionUUID->"3469fe63-468e-49d2-bb71-308cbfba08cc"]
-}, Open  ]],
-
-Cell["Deploy the plugin to a local web server:", "Text",
- TaggingRules->{},
- CellChangeTimes->{{3.889455883491138*^9, 3.889455888612356*^9}},
- CellID->1412944818,ExpressionUUID->"ead09989-6575-4f1a-8c8b-47362a201f15"],
+Cell["Deploy a simple plugin to a local web server:", "Text",
+ CellChangeTimes->{{3.89039848537947*^9, 3.890398492647874*^9}},
+ CellID->388379159,ExpressionUUID->"7f9779d0-70fd-4864-a273-f2c6e17796b7"],
 
 Cell[CellGroupData[{
 
 Cell[BoxData[
  RowBox[{"server", "=", 
-  RowBox[{"ChatGPTPluginDeploy", "[", "plugin", "]"}]}]], "Input",
- TaggingRules->{},
- CellChangeTimes->{{3.889455892665781*^9, 3.889455897961234*^9}},
- CellLabel->"In[10]:=",
- CellID->36080340,ExpressionUUID->"ad9483f3-5372-4521-92dd-95797f4bd772"],
+  RowBox[{"ChatGPTPluginDeploy", "[", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{
+     RowBox[{"\"\<Name\>\"", "->", "\"\<CityPopulationFinder\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<Endpoints\>\"", "->", 
+      RowBox[{"<|", 
+       RowBox[{"\"\<getCityPopulation\>\"", "->", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+          RowBox[{
+           RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], 
+         "]"}]}], "|>"}]}]}], "\[IndentingNewLine]", "|>"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.890398508332391*^9, 3.8903985957004223`*^9}},
+ CellLabel->"In[6]:=",
+ CellID->344476325,ExpressionUUID->"55577ea9-6ad8-45db-9f8f-d72c064e1e5e"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -1485,7 +1241,6 @@ Cell[BoxData[
                     21.188000000000002`}, {52.562, 21.188000000000002`}, {
                     52.562, 8.569}}]}}], 
                    FilledCurveBox[{{
-                    
                     Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
                     51.099000000000004`, 21.188000000000002`}, {49.636, 
                     21.188000000000002`}, {49.636, 8.569}}]}}], 
@@ -1543,7 +1298,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610639962635816118], {
+                    3610800062588910992], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -1738,6 +1493,7 @@ Cell[BoxData[
                     59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
                     4.911}}]}}], 
                   FilledCurveBox[{{
+                    
                     Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
                     56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
                     31.675}}]}}], 
@@ -1775,7 +1531,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610639962635816118], {
+                    3610800062588910992], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -1926,7 +1682,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-82ef6bbe-49b1-4e28-aa20-7309d06c8007\"", 
+                    "\"TCPSERVER-8d84ebac-4a0a-4063-aaec-cb705273edb7\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -2033,7 +1789,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-82ef6bbe-49b1-4e28-aa20-7309d06c8007\"", 
+                    "\"TCPSERVER-8d84ebac-4a0a-4063-aaec-cb705273edb7\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -2060,7 +1816,7 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-82ef6bbe-49b1-4e28-aa20-7309d06c8007"], 
+                   "TCPSERVER-8d84ebac-4a0a-4063-aaec-cb705273edb7"], 
                    Selectable -> False, Editable -> False, SelectWithContents -> 
                    True], "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
@@ -2079,14 +1835,13 @@ Cell[BoxData[
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610639962635816118],
+  SocketListener[3610800062588910992],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
- TaggingRules->{},
- CellChangeTimes->{3.889455898872006*^9, 3.890324053066948*^9},
- CellLabel->"Out[10]=",
- CellID->440096071,ExpressionUUID->"32f0d6d0-539a-440c-8315-b1b786515009"]
+ CellChangeTimes->{{3.890398576842456*^9, 3.8903986058660088`*^9}},
+ CellLabel->"Out[6]=",
+ CellID->1982295402,ExpressionUUID->"8194fd3f-6ddd-4506-b21c-9cb87fe08e11"]
 }, Open  ]],
 
 Cell["Use in ChatGPT:", "Text",
@@ -4344,7 +4099,7 @@ Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  TaggingRules->{},
  CellChangeTimes->{{3.8894570680026712`*^9, 3.889457070158811*^9}},
- CellLabel->"In[11]:=",
+ CellLabel->"In[7]:=",
  CellID->882448711,ExpressionUUID->"1e762b25-7ca3-47b9-9a5a-6a234cef6926"]
 }, Open  ]],
 
@@ -4368,58 +4123,61 @@ Cell[BoxData[{
  RowBox[{"server", "=", 
   RowBox[{"ChatGPTPluginDeploy", "@", 
    RowBox[{"ChatGPTPlugin", "[", 
-    RowBox[{
-     RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{"<|", "\[IndentingNewLine]", 
+     RowBox[{
+      RowBox[{"\"\<Name\>\"", "->", "\"\<TODOList\>\""}], ",", 
+      "\[IndentingNewLine]", 
       RowBox[{
-       RowBox[{"\"\<Name\>\"", "->", "\"\<TODOList\>\""}], ",", 
-       "\[IndentingNewLine]", 
-       RowBox[{
-       "\"\<Prompt\>\"", "->", 
-        "\"\<Plugin for managing a TODO list, you can add, remove and view \
+      "\"\<Prompt\>\"", "->", 
+       "\"\<Plugin for managing a TODO list, you can add, remove and view \
 your TODOs.\>\""}], ",", "\[IndentingNewLine]", 
-       RowBox[{
-       "\"\<Description\>\"", "->", 
-        "\"\<Plugin for managing a TODO list, you can add, remove and view \
-your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",", 
-     "\[IndentingNewLine]", 
-     RowBox[{"{", "\[IndentingNewLine]", 
       RowBox[{
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<getTodos\>\"", ",", "\"\<username\>\"", ",", 
-         RowBox[{
-          RowBox[{"Lookup", "[", 
-           RowBox[{"todos", ",", "#username", ",", 
-            RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}], ",", 
-       "\[IndentingNewLine]", 
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<addTodo\>\"", ",", 
-         RowBox[{"{", 
-          RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
-         RowBox[{
-          RowBox[{"(", 
+      "\"\<Description\>\"", "->", 
+       "\"\<Plugin for managing a TODO list, you can add, remove and view \
+your TODOs.\>\""}], ",", "\[IndentingNewLine]", 
+      RowBox[{"\"\<Endpoints\>\"", "->", 
+       RowBox[{"<|", "\[IndentingNewLine]", 
+        RowBox[{
+         RowBox[{"\"\<getTodos\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
+           RowBox[{"\"\<username\>\"", ",", 
+            RowBox[{
+             RowBox[{"Lookup", "[", 
+              RowBox[{"todos", ",", "#username", ",", 
+               RowBox[{"{", "}"}]}], "]"}], "&"}]}], "]"}]}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"\"\<addTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
            RowBox[{
-            RowBox[{"todos", "[", "#username", "]"}], "=", 
-            RowBox[{"Append", "[", 
-             RowBox[{
-              RowBox[{"Lookup", "[", 
-               RowBox[{"todos", ",", "#username", ",", 
-                RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], ")"}], 
-          "&"}]}], "]"}], ",", "\[IndentingNewLine]", 
-       RowBox[{"ChatGPTPluginEndpoint", "[", 
-        RowBox[{"\"\<deleteTodo\>\"", ",", 
-         RowBox[{"{", 
-          RowBox[{"\"\<username\>\"", ",", 
-           RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], 
-         ",", 
-         RowBox[{
-          RowBox[{"(", 
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", "\"\<todo\>\""}], "}"}], ",", 
+            RowBox[{
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Append", "[", 
+                RowBox[{
+                 RowBox[{"Lookup", "[", 
+                  RowBox[{"todos", ",", "#username", ",", 
+                   RowBox[{"{", "}"}]}], "]"}], ",", "#todo"}], "]"}]}], 
+              ")"}], "&"}]}], "]"}]}], ",", "\[IndentingNewLine]", 
+         RowBox[{"\"\<deleteTodo\>\"", "->", 
+          RowBox[{"APIFunction", "[", 
            RowBox[{
-            RowBox[{"todos", "[", "#username", "]"}], "=", 
-            RowBox[{"Delete", "[", 
-             RowBox[{
-              RowBox[{"todos", "[", "#username", "]"}], ",", 
-              RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], "&"}]}], 
-        "]"}]}], "\[IndentingNewLine]", "}"}]}], "\[IndentingNewLine]", 
+            RowBox[{"{", 
+             RowBox[{"\"\<username\>\"", ",", 
+              RowBox[{"\"\<todo_idx\>\"", "->", "\"\<Integer\>\""}]}], "}"}], 
+            ",", 
+            RowBox[{
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"todos", "[", "#username", "]"}], "=", 
+               RowBox[{"Delete", "[", 
+                RowBox[{
+                 RowBox[{"todos", "[", "#username", "]"}], ",", 
+                 RowBox[{"#\"todo_idx\"", "-", "1"}]}], "]"}]}], ")"}], 
+             "&"}]}], "]"}]}]}], "\[IndentingNewLine]", "|>"}]}]}], 
+     "\[IndentingNewLine]", "|>"}], "\[IndentingNewLine]", 
     "]"}]}]}]}], "Input",
  TaggingRules->{},
  CellChangeTimes->{{3.8892965279564943`*^9, 3.889296531899847*^9}, {
@@ -4430,8 +4188,8 @@ your TODOs.\>\""}]}], "\[IndentingNewLine]", "|>"}], ",",
    3.88941170940053*^9, 3.889411712451518*^9}, 3.889450158192483*^9, 
    3.8894503830116034`*^9, {3.889450484885947*^9, 3.889450491289304*^9}, {
    3.889454945124021*^9, 3.8894549453458643`*^9}, {3.889474478392243*^9, 
-   3.889474499492263*^9}},
- CellLabel->"In[12]:=",
+   3.889474499492263*^9}, {3.890398613335616*^9, 3.8903986529149714`*^9}},
+ CellLabel->"In[8]:=",
  CellID->41348088,ExpressionUUID->"99f47b18-e7b1-41a3-b190-01ab95057e4f"],
 
 Cell[BoxData[
@@ -4652,7 +4410,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640443527580670], {
+                    3610800167399979979], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -4885,7 +4643,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610640443527580670], {
+                    3610800167399979979], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -5036,7 +4794,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-9482b7ae-83b3-4f88-b524-6ce3cf809c45\"", 
+                    "\"TCPSERVER-3d03789c-24c2-42be-8031-9042620bc044\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -5143,7 +4901,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-9482b7ae-83b3-4f88-b524-6ce3cf809c45\"", 
+                    "\"TCPSERVER-3d03789c-24c2-42be-8031-9042620bc044\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -5170,7 +4928,7 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-9482b7ae-83b3-4f88-b524-6ce3cf809c45"], 
+                   "TCPSERVER-3d03789c-24c2-42be-8031-9042620bc044"], 
                    Selectable -> False, Editable -> False, SelectWithContents -> 
                    True], "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
@@ -5189,15 +4947,15 @@ Cell[BoxData[
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610640443527580670],
+  SocketListener[3610800167399979979],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
  TaggingRules->{},
  CellChangeTimes->{{3.8894744842485857`*^9, 3.889474500147913*^9}, 
-   3.8903242766498423`*^9},
- CellLabel->"Out[13]=",
- CellID->1721332831,ExpressionUUID->"b754c9d5-bdb0-4f60-bd14-131912e6a03d"]
+   3.8903242766498423`*^9, 3.890398654285071*^9},
+ CellLabel->"Out[9]=",
+ CellID->1768636398,ExpressionUUID->"3be12875-8a9e-4345-b597-a7e01d5c7708"]
 }, Open  ]],
 
 Cell["Install and use the plugin:", "Text",
@@ -7863,7 +7621,7 @@ Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  TaggingRules->{},
  CellChangeTimes->{{3.889473081013341*^9, 3.889473083050357*^9}},
- CellLabel->"In[14]:=",
+ CellLabel->"In[10]:=",
  CellID->895527148,ExpressionUUID->"a109f436-67c4-487c-8df7-3f4cfabc751d"],
 
 Cell[BoxData[
@@ -9993,1737 +9751,7 @@ DockedCells->{
    CellFrameMargins -> {{0, 0}, {2, 2}}, CellFrame -> {{0, 0}, {1, 0}}, 
    CacheGraphics -> False, CellOpen -> Dynamic[
      CurrentValue[
-      EvaluationNotebook[], {TaggingRules, "ToolsOpen"}, True]]], 
-  Cell[
-   BoxData[
-    StyleBox[
-     InterpretationBox[
-      StyleBox[
-       PaneSelectorBox[{False -> GridBox[{{
-             OpenerBox[
-              Dynamic[
-               CurrentValue[
-                EvaluationCell[], {TaggingRules, "StripeOpen"}, False]], 
-              Appearance -> Automatic, Enabled -> Automatic, AutoAction -> 
-              False, ContinuousAction -> False], 
-             TagBox[
-              GridBox[{{
-                 StyleBox[
-                  DynamicBox[
-                   ToBoxes[
-                    DateString[
-                    TimeZoneConvert[
-                    DateObject[
-                    3.890324912210944`16.342560863413077*^9, TimeZone -> 
-                    0]], {"MonthName", " ", "DayShort", ", ", "Year", " ", 
-                    "Hour12Short", ":", "Minute", " ", "AMPMLowerCase"}], 
-                    StandardForm], SingleEvaluation -> True, Evaluator -> 
-                   "System"], FontSlant -> Italic, FontColor -> 
-                  GrayLevel[0.5], FontSize -> 0.9 Inherited, StripOnInput -> 
-                  False], "\"   \"", 
-                 ItemBox[
-                  StyleBox[
-                   TagBox[
-                    GridBox[{{
-                    TagBox[
-                    TagBox[
-                    GridBox[{{
-                    StyleBox["\"\[Checkmark]\"", FontColor -> RGBColor[0, 
-                    Rational[2, 3], 0], FontSize -> 16, FontWeight -> "Heavy",
-                     StripOnInput -> False], "\"\"", 
-                    "\"Your paclet resource is being published\""}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{0.25}}, "ColumnsIndexed" -> {2 -> 0.1}, 
-                    "Rows" -> {{Automatic}}}], "Grid"], Annotation[#, 
-                    
-                    DefinitionNotebookClient`Stripes`PackagePrivate`$\
-stripeText["Your paclet resource is being published"]]& ], "\"\""}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {"Columns" -> {{0.25}}}], "Grid"], 
-                   LineBreakWithin -> Automatic, LineIndent -> 0, 
-                   StripOnInput -> False], ItemSize -> Fit, StripOnInput -> 
-                  False], 
-                 ItemBox[
-                  StyleBox[
-                  "\"\"", LineBreakWithin -> Automatic, LineIndent -> 0, 
-                   StripOnInput -> False], ItemSize -> Fit, StripOnInput -> 
-                  False], 
-                 StyleBox[
-                  ActionMenuBox[
-                   TemplateBox[{
-                    TemplateBox[{
-                    TagBox[
-                    GridBox[{{
-                    TemplateBox[{
-                    TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {12, 12}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], 
-                    TemplateBox[{1}, "Spacer1"], 
-                    StyleBox[
-                    "3", FontSize -> 14, FontWeight -> Plain, FontColor -> 
-                    GrayLevel[0.25], FontFamily -> "Source Sans Pro", 
-                    StripOnInput -> False]}, "RowDefault"], 
-                    "\"Potential issues found\""}, "PrettyTooltipTemplate"]}},
-                     AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-                    "Grid"], 
-                    GraphicsBox[{
-                    GrayLevel[0.4], 
-                    AbsoluteThickness[2], 
-                    CapForm["Round"], 
-                    LineBox[{{-1, 0}, {0, -1}, {1, 0}}]}, {
-                    ImageSize -> {13, 9}, BaselinePosition -> Scaled[0.2], 
-                    ImagePadding -> {{3, 3}, {3, 3}}, AspectRatio -> Full}]}, 
-                    "RowDefault"], ImageSize -> {Automatic, 19}, 
-                    BaselinePosition -> Baseline, Background -> GrayLevel[1], 
-                    FrameStyle -> Dynamic[
-                    If[
-                    CurrentValue["MouseOver"], 
-                    Hue[0.55, 0.82, 0.87], 
-                    GrayLevel[0.8]]], FrameMargins -> {{4, 4}, {1, 1}}, 
-                    Alignment -> {Center, Baseline}}, "Highlighted"], {
-                   TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"New submissions should typically be version 1.0.0\""}, 
-                    "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "aed155fd-a858-451b-81e5-cdfd55e71bc6", 22849867, 
-                    "InvalidFirstVersion", <|
-                    "Current" -> "1.0.2", "Published" -> None, 
-                    "Selection" -> ("Version" -> "1.0.2"), "PublisherID" -> 
-                    "Wolfram", "PacletDirectory" -> 
-                    File["/Users/christopher/git/ChatGPTPluginKit/\
-ChatGPTPluginKit"], "ResourceName" -> "Wolfram/ChatGPTPluginKit"|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[22849867]; 
-                    Null], TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"This cell has excessive height. Consider reducing the \
-size to avoid potential issues.\""}, "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "647f617d-bc8f-4ba6-bcc2-832c3c12b13c", 1822574373, 
-                    "LargeCellBounds/CellHeight", <|
-                    "Type" -> "height", "CellID" -> 1822574373, "CellObject" -> 
-                    CellObject[
-                    "9632ecf7-afa9-422e-926c-8cb13c53fac8", 
-                    "a4bf90e3-d762-4a14-97d1-38e91da04ee6"], 
-                    "CellSerialNumber" -> 67522, "CellSize" -> {298, 531}, 
-                    "CellTags" -> {}, "ContentData" -> BoxData, 
-                    "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                    None, "Evaluatable" -> False, "Evaluating" -> False, 
-                    "ExpressionUUID" -> 
-                    "9632ecf7-afa9-422e-926c-8cb13c53fac8", 
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                    "NeedsRendering" -> False, "Position" -> 51, "Rendering" -> 
-                    False, "Style" -> "ExampleImage", "TemplateGroup" -> 
-                    False, "TemplateGroupName" -> None, "Area" -> 500000., 
-                    "Height" -> 500., "Width" -> 2000|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[
-                    1822574373]; Null], TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"This cell has excessive height. Consider reducing the \
-size to avoid potential issues.\""}, "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "04ae0cf3-7e8d-44c3-b536-66e3f24bcca1", 1491546085, 
-                    "LargeCellBounds/CellHeight", <|
-                    "Type" -> "height", "CellID" -> 1491546085, "CellObject" -> 
-                    CellObject[
-                    "a066330f-e087-46ff-95e8-20a72804c260", 
-                    "02f91343-4bd5-4cb9-945c-b7c08fa9e2d4"], 
-                    "CellSerialNumber" -> 67530, "CellSize" -> {316, 546}, 
-                    "CellTags" -> {}, "ContentData" -> BoxData, 
-                    "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                    None, "Evaluatable" -> False, "Evaluating" -> False, 
-                    "ExpressionUUID" -> 
-                    "a066330f-e087-46ff-95e8-20a72804c260", 
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                    "NeedsRendering" -> False, "Position" -> 59, "Rendering" -> 
-                    False, "Style" -> "ExampleImage", "TemplateGroup" -> 
-                    False, "TemplateGroupName" -> None, "Area" -> 500000., 
-                    "Height" -> 500., "Width" -> 2000|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[
-                    1491546085]; Null]}, Appearance -> None], "BoxID" -> 
-                  "WarningCountButton", StripOnInput -> False], 
-                 TagBox[
-                  ButtonBox[
-                   TagBox[
-                    PaneSelectorBox[{False -> GraphicsBox[{
-                    GrayLevel[
-                    NCache[
-                    Rational[64, 85], 0.7529411764705882]], 
-                    
-                    PolygonBox[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                    0.42426406871192845`}, {0.42426406871192845`, 
-                    0.282842712474619}}], 
-                    
-                    PolygonBox[{{0.42426406871192845`, -0.282842712474619}, {
-                    0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                    0.42426406871192845`}}]}, ImageSize -> 18, 
-                    PlotRangePadding -> 0, PlotRange -> 0.7, Background -> 
-                    None], True -> GraphicsBox[{
-                    GrayLevel[
-                    NCache[
-                    Rational[128, 255], 0.5019607843137255]], 
-                    
-                    PolygonBox[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                    0.42426406871192845`}, {0.42426406871192845`, 
-                    0.282842712474619}}], 
-                    
-                    PolygonBox[{{0.42426406871192845`, -0.282842712474619}, {
-                    0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                    0.42426406871192845`}}]}, ImageSize -> 18, 
-                    PlotRangePadding -> 0, PlotRange -> 0.7, Background -> 
-                    None]}, 
-                    Dynamic[
-                    CurrentValue["MouseOver"]], ImageSize -> Automatic, 
-                    FrameMargins -> 0], 
-                    MouseAppearanceTag["LinkHand"]], ButtonFunction :> 
-                   With[{DefinitionNotebookClient`Stripes`PackagePrivate`nbo$ = 
-                    EvaluationNotebook[]}, 
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells] = If[
-                    TrueQ[
-                    MemberQ[
-                    CurrentValue["ModifierKeys"], "Control"]], 
-                    DeleteCases[
-                    Flatten[{
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                    Cell[
-                    Blank[], "StripeCell", 
-                    BlankNullSequence[]]], 
-                    DeleteCases[
-                    Flatten[{
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                    Condition[
-                    Pattern[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                    Blank[Cell]], 
-                    Not[
-                    FreeQ[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                    "a644fe0b-77e5-44a5-8592-6b8ec3dde629"]]]]]], Appearance -> 
-                   None, BoxID -> "a644fe0b-77e5-44a5-8592-6b8ec3dde629", 
-                   Evaluator -> Automatic, Method -> "Preemptive"], 
-                  MouseAppearanceTag["LinkHand"]]}}, 
-               GridBoxAlignment -> {
-                "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, AutoDelete -> 
-               False, GridBoxItemSize -> {
-                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-              "Grid"]}}, GridBoxAlignment -> {"Columns" -> {{Left}}}, 
-           AutoDelete -> False, 
-           GridBoxBackground -> {"Columns" -> {{Automatic}}}, 
-           GridBoxItemSize -> {
-            "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-           GridBoxSpacings -> {"Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
-           BaselinePosition -> {1, 1}], True -> GridBox[{{
-             OpenerBox[
-              Dynamic[
-               CurrentValue[
-                EvaluationCell[], {TaggingRules, "StripeOpen"}, False]], 
-              Appearance -> Automatic, Enabled -> Automatic, AutoAction -> 
-              False, ContinuousAction -> False], 
-             TagBox[
-              GridBox[{{
-                 StyleBox[
-                  DynamicBox[
-                   ToBoxes[
-                    DateString[
-                    TimeZoneConvert[
-                    DateObject[
-                    3.890324912210944`16.342560863413077*^9, TimeZone -> 
-                    0]], {"MonthName", " ", "DayShort", ", ", "Year", " ", 
-                    "Hour12Short", ":", "Minute", " ", "AMPMLowerCase"}], 
-                    StandardForm], SingleEvaluation -> True, Evaluator -> 
-                   "System"], FontSlant -> Italic, FontColor -> 
-                  GrayLevel[0.5], FontSize -> 0.9 Inherited, StripOnInput -> 
-                  False], "\"   \"", 
-                 ItemBox[
-                  StyleBox[
-                   TagBox[
-                    GridBox[{{
-                    TagBox[
-                    TagBox[
-                    GridBox[{{
-                    StyleBox["\"\[Checkmark]\"", FontColor -> RGBColor[0, 
-                    Rational[2, 3], 0], FontSize -> 16, FontWeight -> "Heavy",
-                     StripOnInput -> False], "\"\"", 
-                    "\"Your paclet resource is being published\""}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{0.25}}, "ColumnsIndexed" -> {2 -> 0.1}, 
-                    "Rows" -> {{Automatic}}}], "Grid"], Annotation[#, 
-                    
-                    DefinitionNotebookClient`Stripes`PackagePrivate`$\
-stripeText["Your paclet resource is being published"]]& ], "\"\""}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {"Columns" -> {{0.25}}}], "Grid"], 
-                   LineBreakWithin -> Automatic, LineIndent -> 0, 
-                   StripOnInput -> False], ItemSize -> Fit, StripOnInput -> 
-                  False], 
-                 ItemBox[
-                  StyleBox[
-                  "\"\"", LineBreakWithin -> Automatic, LineIndent -> 0, 
-                   StripOnInput -> False], ItemSize -> Fit, StripOnInput -> 
-                  False], 
-                 StyleBox[
-                  ActionMenuBox[
-                   TemplateBox[{
-                    TemplateBox[{
-                    TagBox[
-                    GridBox[{{
-                    TemplateBox[{
-                    TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {12, 12}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], 
-                    TemplateBox[{1}, "Spacer1"], 
-                    StyleBox[
-                    "3", FontSize -> 14, FontWeight -> Plain, FontColor -> 
-                    GrayLevel[0.25], FontFamily -> "Source Sans Pro", 
-                    StripOnInput -> False]}, "RowDefault"], 
-                    "\"Potential issues found\""}, "PrettyTooltipTemplate"]}},
-                     AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-                    "Grid"], 
-                    GraphicsBox[{
-                    GrayLevel[0.4], 
-                    AbsoluteThickness[2], 
-                    CapForm["Round"], 
-                    LineBox[{{-1, 0}, {0, -1}, {1, 0}}]}, {
-                    ImageSize -> {13, 9}, BaselinePosition -> Scaled[0.2], 
-                    ImagePadding -> {{3, 3}, {3, 3}}, AspectRatio -> Full}]}, 
-                    "RowDefault"], ImageSize -> {Automatic, 19}, 
-                    BaselinePosition -> Baseline, Background -> GrayLevel[1], 
-                    FrameStyle -> Dynamic[
-                    If[
-                    CurrentValue["MouseOver"], 
-                    Hue[0.55, 0.82, 0.87], 
-                    GrayLevel[0.8]]], FrameMargins -> {{4, 4}, {1, 1}}, 
-                    Alignment -> {Center, Baseline}}, "Highlighted"], {
-                   TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"New submissions should typically be version 1.0.0\""}, 
-                    "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "aed155fd-a858-451b-81e5-cdfd55e71bc6", 22849867, 
-                    "InvalidFirstVersion", <|
-                    "Current" -> "1.0.2", "Published" -> None, 
-                    "Selection" -> ("Version" -> "1.0.2"), "PublisherID" -> 
-                    "Wolfram", "PacletDirectory" -> 
-                    File["/Users/christopher/git/ChatGPTPluginKit/\
-ChatGPTPluginKit"], "ResourceName" -> "Wolfram/ChatGPTPluginKit"|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[22849867]; 
-                    Null], TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"This cell has excessive height. Consider reducing the \
-size to avoid potential issues.\""}, "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "647f617d-bc8f-4ba6-bcc2-832c3c12b13c", 1822574373, 
-                    "LargeCellBounds/CellHeight", <|
-                    "Type" -> "height", "CellID" -> 1822574373, "CellObject" -> 
-                    CellObject[
-                    "9632ecf7-afa9-422e-926c-8cb13c53fac8", 
-                    "a4bf90e3-d762-4a14-97d1-38e91da04ee6"], 
-                    "CellSerialNumber" -> 67522, "CellSize" -> {298, 531}, 
-                    "CellTags" -> {}, "ContentData" -> BoxData, 
-                    "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                    None, "Evaluatable" -> False, "Evaluating" -> False, 
-                    "ExpressionUUID" -> 
-                    "9632ecf7-afa9-422e-926c-8cb13c53fac8", 
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                    "NeedsRendering" -> False, "Position" -> 51, "Rendering" -> 
-                    False, "Style" -> "ExampleImage", "TemplateGroup" -> 
-                    False, "TemplateGroupName" -> None, "Area" -> 500000., 
-                    "Height" -> 500., "Width" -> 2000|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[
-                    1822574373]; Null], TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {10, 10}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], "\" \"", 
-                    "\"This cell has excessive height. Consider reducing the \
-size to avoid potential issues.\""}, "RowDefault"] :> 
-                    DefinitionNotebookClient`WithCurrentNotebook[
-                    EvaluationNotebook[], 
-                    DefinitionNotebookClient`LoadDefinitionNotebook[
-                    "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                    DefinitionNotebookClient`PackageScope`setHint[
-                    "Warning", "Paclet", 
-                    DefinitionNotebookClient`$CurrentNotebook, 
-                    "04ae0cf3-7e8d-44c3-b536-66e3f24bcca1", 1491546085, 
-                    "LargeCellBounds/CellHeight", <|
-                    "Type" -> "height", "CellID" -> 1491546085, "CellObject" -> 
-                    CellObject[
-                    "a066330f-e087-46ff-95e8-20a72804c260", 
-                    "02f91343-4bd5-4cb9-945c-b7c08fa9e2d4"], 
-                    "CellSerialNumber" -> 67530, "CellSize" -> {316, 546}, 
-                    "CellTags" -> {}, "ContentData" -> BoxData, 
-                    "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                    None, "Evaluatable" -> False, "Evaluating" -> False, 
-                    "ExpressionUUID" -> 
-                    "a066330f-e087-46ff-95e8-20a72804c260", 
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                    "NeedsRendering" -> False, "Position" -> 59, "Rendering" -> 
-                    False, "Style" -> "ExampleImage", "TemplateGroup" -> 
-                    False, "TemplateGroupName" -> None, "Area" -> 500000., 
-                    "Height" -> 500., "Width" -> 2000|>]; 
-                    DefinitionNotebookClient`PackageScope`seekAfter[
-                    1491546085]; Null]}, Appearance -> None], "BoxID" -> 
-                  "WarningCountButton", StripOnInput -> False], 
-                 TagBox[
-                  ButtonBox[
-                   TagBox[
-                    PaneSelectorBox[{False -> GraphicsBox[{
-                    GrayLevel[
-                    NCache[
-                    Rational[64, 85], 0.7529411764705882]], 
-                    
-                    PolygonBox[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                    0.42426406871192845`}, {0.42426406871192845`, 
-                    0.282842712474619}}], 
-                    
-                    PolygonBox[{{0.42426406871192845`, -0.282842712474619}, {
-                    0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                    0.42426406871192845`}}]}, ImageSize -> 18, 
-                    PlotRangePadding -> 0, PlotRange -> 0.7, Background -> 
-                    None], True -> GraphicsBox[{
-                    GrayLevel[
-                    NCache[
-                    Rational[128, 255], 0.5019607843137255]], 
-                    
-                    PolygonBox[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                    0.42426406871192845`}, {0.42426406871192845`, 
-                    0.282842712474619}}], 
-                    
-                    PolygonBox[{{0.42426406871192845`, -0.282842712474619}, {
-                    0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                    0.42426406871192845`}}]}, ImageSize -> 18, 
-                    PlotRangePadding -> 0, PlotRange -> 0.7, Background -> 
-                    None]}, 
-                    Dynamic[
-                    CurrentValue["MouseOver"]], ImageSize -> Automatic, 
-                    FrameMargins -> 0], 
-                    MouseAppearanceTag["LinkHand"]], ButtonFunction :> 
-                   With[{DefinitionNotebookClient`Stripes`PackagePrivate`nbo$ = 
-                    EvaluationNotebook[]}, 
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells] = If[
-                    TrueQ[
-                    MemberQ[
-                    CurrentValue["ModifierKeys"], "Control"]], 
-                    DeleteCases[
-                    Flatten[{
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                    Cell[
-                    Blank[], "StripeCell", 
-                    BlankNullSequence[]]], 
-                    DeleteCases[
-                    Flatten[{
-                    CurrentValue[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                    Condition[
-                    Pattern[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                    Blank[Cell]], 
-                    Not[
-                    FreeQ[
-                    DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                    "a644fe0b-77e5-44a5-8592-6b8ec3dde629"]]]]]], Appearance -> 
-                   None, BoxID -> "a644fe0b-77e5-44a5-8592-6b8ec3dde629", 
-                   Evaluator -> Automatic, Method -> "Preemptive"], 
-                  MouseAppearanceTag["LinkHand"]]}}, 
-               GridBoxAlignment -> {
-                "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, AutoDelete -> 
-               False, GridBoxItemSize -> {
-                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
-              "Grid"]}, {"", 
-             PaneBox[
-              TagBox[
-               GridBox[{{"\"\"", 
-                  StyleBox[
-                   TagBox[
-                    
-                    GridBox[{{
-                    "\"\[FilledVerySmallSquare]\"", "\"Submission result:\"", 
-                    
-                    TemplateBox[{
-                    TagBox[
-                    RowBox[{
-                    TagBox["Success", "SummaryHead"], "[", 
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxOpener"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 (CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification])}]], 
-                    FrameBox[
-                    StyleBox["\"\[Checkmark]\"", 
-                    Directive[
-                    RGBColor[
-                    0.3607843137254902, 0.596078431372549, 
-                    0.3803921568627451], 25], StripOnInput -> False], 
-                    ContentPadding -> False, FrameStyle -> None, 
-                    FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"Your paclet resource is being published\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Name\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Wolfram/ChatGPTPluginKit\"", "SummaryItem"]}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxCloser"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 3.5 (CurrentValue["FontCapHeight"]/
-                    AbsoluteCurrentValue[Magnification])}]], 
-                    FrameBox[
-                    StyleBox["\"\[Checkmark]\"", 
-                    Directive[
-                    RGBColor[
-                    0.3607843137254902, 0.596078431372549, 
-                    0.3803921568627451], 25], StripOnInput -> False], 
-                    ContentPadding -> False, FrameStyle -> None, 
-                    FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"Your paclet resource is being published\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Name\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Wolfram/ChatGPTPluginKit\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"UUID\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"ab885183-1b32-478a-9b3e-dc7ccadc8029\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"ResourceType\"", "\": \""}, "RowDefault"],
-                     "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Paclet\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Warnings\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    RowBox[{"{", "}"}], "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Version\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"1.0.2\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"SubmissionID\"", "\": \""}, "RowDefault"],
-                     "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"8697\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    
-                    TemplateBox[{"\"DirectCreation\"", "\": \""}, 
-                    "RowDefault"], "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["True", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"ResourceSubmission\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
-                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                    Short[#, 0.75]& ], 
-                    "OEM6eJztWE1vG0UYjuNvx3VDGwT0FK0iUA8uTQLE4RKcTZxGNKnlcRsQQ\
-up497U9Ynd2NTOb1CB+AieuHPhXcIYfwE+Ad/bDdjaJFBxXcPBedjXv1zPvt7afkaUOvdj33oDs5+\
-U7x1yB8AUoqpjH8bifkYWOpxn6OZl7zqTqL8tClw7whBRJYFkgJVkhgetSMXoG1CaZb/\
-pZuXow4tRl1olnBw5o8eWxeJaAkrXuyAcJ6rXnA9/\
-YkPkWdSQk1LWECm4PbIJwYGOD5Duof4Q8K11wfQcPI4SR4qy836YcCDhgKU9ctpnrIIzESF4WjwSzL\
-wsn76JWokkFWd4PlErcUIlvFOl91DpsC3aOEF63hMfVIbc7IL1AWEDKrcN9plzqS7IaOwaFXuA9QWj\
-wGsoBOHQEtqxFJloBt7THb/JOrisCGF+j0vR9oIJydH7u1OMTSnmfSiBq5EB/\
-KXX38uE5dQKKnpHlZqA8F0NsjamFE1BDzyaVtgD0rWLnU0qbDhtwF7hKHCoLJuhMSd4T1mOXDoCw7w\
-E9Vow9Npa6ZDffZS5IsRQ+1S/GJyhYNQMhUPErBAzkXgv9a1L/GbDBUEPIt70LtJmRa82e9JxAwTS/\
-vHdCB5z1mRXmsPk3hrvUEtQNg5qVpdA9On3zxh+//GygwvIBE5gz+s5I7xztm57jCfFe+\
-Py2Jx6Gz5974qvw+X3P/GB84ypRgvkv+\
-DH3AzXJ4ohYMxE6AmtT22Z8kCZXQlghnlQcqyHlhIoB43I6jfXbXDKX0t83YylMkj3Rkxm/\
-k9rOpms7XWSxKCkbJ1jwGGOD5IzP1w1SQQ0H0KeBo8i7cbYfK3CbnHtRFyHZv376daprPDa+\
-xjpZ96nlgFoXcdWsM7neA3TSuh/0HCaHYBvjvqIV3gV1wThFd84O+\
-ZFx5jl9DMnH5pCqo3a37QQYmS+ZSmFMIrEau/xK5SQcpIg5FrhcTl0rKpLcc+\
-hP2HKI9SrPNQVc0UfYVUBBOs3ux2A0wrA0b43lqp3bA0qsEgy0zv1bWzWX/72xqb6XS/\
-W9NTL0LnRh8AEGT1BL9620i1ZOAxw0Agvuuyu0GjZ6LGHsEEzqhpKdRDlUPeKKvomKOC36ltMg2/\
-X8/28CrOqYOIxD25MsHm5RgDNmZswVTbb/ZCKbjidnnsjpVr4YyYuRPMNILi9G8lseyXfC+\
-PLl8cHsGD80aK/R+HSzsV3f7G1v1T/\
-ZadD6bm8b6ra1Y1nUthpPt3bnh7dmJB1PN6vZcZeMdpgJ80NWMc6o4LreZkY1ZTbRmvmBZH6cG8ay8\
-QrbJxqe3XFFY/PJ0ydb84woCXoukxrWXTKxYDQ+292ZH65VI+rPpoDQ3uzIwvk/N1x5A+\
-mzg1kbF9DE7YsNf7HhLzb8GTb8ybaZXp6v2U2n1JNqXG967XfS6/nDSz8Wo/UyWaxJ5ltkH/+\
-VfHC1mJulOinG6xL56JZLT53k9K5C3r9p40AGvSiQjduM+\
-zqpTk9pUohmbZ2UkhGZXAehxhOJ5MO5UteumYwDktNNvU5ql3tx+\
-mdh9EOU9pwrWVM6tNm1hAeRzBlTw3hdlpHWfwC2bII3"}, "ClickToCopyTemplate"]}, {
-                    "\"\[FilledVerySmallSquare]\"", "\"Resource object:\"", 
-                    TemplateBox[{
-                    TagBox[
-                    RowBox[{"ResourceObject", "[", 
-                    ButtonBox[
-                    TagBox[
-                    GridBox[{{
-                    GraphicsBox[{
-                    Thickness[0.0025], {
-                    FaceForm[{
-                    RGBColor[
-                    0.9607843137254902, 0.5058823529411764, 
-                    0.19607843137254902`], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {1, 3, 3}, {0, 1, 
-                    0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
-                    3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
-                    3}}}, {{{205., 22.660200119018555`}, {205., 
-                    212.11320304870605`}, {246.01799774169922`, 
-                    235.79520988464355`}, {369.0710144042969, 
-                    306.8401927947998}, {369.0710144042969, 
-                    117.38719749450684`}, {205., 22.660200119018555`}}, {{
-                    30.928985595703125`, 306.8401927947998}, {
-                    153.98200225830078`, 235.79520988464355`}, {195., 
-                    212.11320304870605`}, {195., 22.660200119018555`}, {
-                    30.928985595703125`, 117.38719749450684`}, {
-                    30.928985595703125`, 306.8401927947998}}, {{200., 
-                    410.22620964050293`}, {364.0710144042969, 
-                    315.5001964569092}, {241.01799774169922`, 
-                    244.45519828796387`}, {200., 220.77320671081543`}, {
-                    158.98200225830078`, 244.45519828796387`}, {
-                    35.928985595703125`, 315.5001964569092}, {200., 
-                    410.22620964050293`}}, CompressedData["
-1:eJxTTMoPSmViYGCQAWIQDQQPlDrLHYB0n8ffYgewSEAmhO9aBaJ/1cmB+XqT
-gsF8tsaHGch8BoYNGcjqGS7lmqOYd/qhKYg+9+8dhH/prQmI9ptyBYV/jmEH
-Cj+CeUEMMr9iq24MsnkV3Eeike2b8aQrGtk9DSrhyiA6e88JMD/BvUgJbG/S
-EzBfQYpBCaKeIROZv2muNDK/YaqzeSayflj4wMyHhR/M/oDHC8uR3fdAaWM5
-svthfJj/YHyY/2F8WPjAzIOFH0p8AQA7u3Ea
-                    "]}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{43., 198.67381286621094`}, {107.71399688720703`, 
-                    161.3118133544922}, {107.71399688720703`, 
-                    86.58680725097656}, {43., 123.94882202148438`}, {43., 
-                    198.67381286621094`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.3137254901960784, 0.4549019607843137, 
-                    0.611764705882353], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{182.77679443359375`, 198.67381286621094`}, {
-                    182.77679443359375`, 123.94882202148438`}, {
-                    118.06279754638672`, 86.58680725097656}, {
-                    118.06279754638672`, 161.3118133544922}, {
-                    182.77679443359375`, 198.67381286621094`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.7803921568627451, 0.8627450980392157, 
-                    0.9490196078431372], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{112.8884048461914, 244.9990997314453}, {
-                    177.60240173339844`, 207.63610076904297`}, {
-                    112.8884048461914, 170.27410888671875`}, {
-                    48.174407958984375`, 207.63610076904297`}, {
-                    112.8884048461914, 244.9990997314453}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{130.02911376953125`, 350.11590576171875`}, {
-                    194.80210876464844`, 312.7189064025879}, {
-                    194.80210876464844`, 237.92591094970703`}, {
-                    130.02911376953125`, 275.32291412353516`}, {
-                    130.02911376953125`, 350.11590576171875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.4627450980392157, 0.3607843137254902, 
-                    0.611764705882353], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{269.9334716796875, 350.11590576171875`}, {
-                    269.9334716796875, 275.32291412353516`}, {
-                    205.1604766845703, 237.92591094970703`}, {
-                    205.1604766845703, 312.7189064025879}, {269.9334716796875,
-                     350.11590576171875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.8862745098039215, 0.803921568627451, 
-                    0.9529411764705882], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{199.98130798339844`, 396.48345947265625`}, {
-                    264.7543029785156, 359.0864601135254}, {
-                    199.98130798339844`, 321.69046783447266`}, {
-                    135.20831298828125`, 359.0864601135254}, {
-                    199.98130798339844`, 396.48345947265625`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{217.61199951171875`, 199.13890075683594`}, {
-                    281.8990020751953, 162.0229034423828}, {281.8990020751953,
-                     87.7908935546875}, {217.61199951171875`, 
-                    124.90690612792969`}, {217.61199951171875`, 
-                    199.13890075683594`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.43137254901960786`, 0.6039215686274509, 
-                    0.34509803921568627`], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{356.46661376953125`, 199.13890075683594`}, {
-                    356.46661376953125`, 124.90690612792969`}, {
-                    292.1796112060547, 87.7908935546875}, {292.1796112060547, 
-                    162.0229034423828}, {356.46661376953125`, 
-                    199.13890075683594`}}}]}, {
-                    FaceForm[{
-                    RGBColor[0.8549019607843137, 0.9450980392156862, 0.8], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{287.039306640625, 245.15859985351562`}, {
-                    351.32630920410156`, 208.0426025390625}, {
-                    287.039306640625, 170.92660522460938`}, {
-                    222.75230407714844`, 208.0426025390625}, {
-                    287.039306640625, 245.15859985351562`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    356.46649169921875`, 215.76849365234375`}, {
-                    296.2834930419922, 250.5924949645996}, {
-                    356.46649169921875`, 285.26649475097656`}, {
-                    356.46649169921875`, 215.76849365234375`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    217.61199951171875`, 114.06449890136719`}, {
-                    277.7949981689453, 79.24049758911133}, {
-                    217.61199951171875`, 44.566497802734375`}, {
-                    217.61199951171875`, 114.06449890136719`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    122.17269897460938`, 78.36309814453125}, {
-                    182.42269897460938`, 113.07109832763672`}, {
-                    182.35969924926758`, 43.614097595214844`}, {
-                    122.17269897460938`, 78.36309814453125}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    103.52159881591797`, 249.46669006347656`}, {
-                    43.27159881591797, 214.7586898803711}, {
-                    43.334598541259766`, 284.21569061279297`}, {
-                    103.52159881591797`, 249.46669006347656`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    120.86710357666016`, 350.61541748046875`}, {
-                    120.80010357499123`, 281.0834197998047}, {
-                    60.68010330200195, 315.86641693115234`}, {
-                    120.86710357666016`, 350.61541748046875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    278.3727111816406, 281.2159118652344}, {
-                    278.43971118330956`, 350.74790954589844`}, {
-                    338.5597114562988, 315.9649124145508}, {278.3727111816406,
-                     281.2159118652344}}}]}}, {
-                    ImageSize -> 12, BaselinePosition -> Scaled[0.1], 
-                    ImageSize -> {Automatic, 35}}], 
-                    StyleBox[
-                    "\"Wolfram/ChatGPTPluginKit\"", FontFamily -> Dynamic[
-                    CurrentValue["PanelFontFamily"]], FontSize -> 
-                    0.8 Inherited, ShowStringCharacters -> False, 
-                    StripOnInput -> False]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{0.25}}, "Rows" -> {{0}}}], "Grid"], 
-                    ButtonFunction :> {}, Evaluator -> None, Active -> False, 
-                    Alignment -> Left, 
-                    Appearance -> {
-                    "Default" -> FrontEnd`FileName[{"Typeset", "SummaryBox"}, 
-                    "Panel.9.png"]}, FrameMargins -> {{3, 3}, {3, 0}}, 
-                    BaseStyle -> {Deployed -> False}, 
-                    DefaultBaseStyle -> {Background -> None}, 
-                    BaselinePosition -> Baseline, Method -> "Preemptive"], 
-                    "]"}], Short[#, 0.75]& ], 
-                    "OEM6eJztW31sFMcVv/\
-OdbfwJJm7SkrQ6LVaVVvEHNtQOUnNnn322FQMnjw0kQOq9vTnf4r3dZWbP56MSchtUKU1KaIGGpg0x\
-balS/qgIUiXybZpWaRU1lShtrdI2dghRURpAVZISlDadmd2521vb4gwG8sc9IS9v5s2833vz5oP3cM\
-yNl/SLqQ5tDOJYMa7pVQ2IdAQN0ZA1lTTH3LikX6MCMS/\
-29snYiBXhkgFxmLSA6n6ItSSS4IbIdigZoAIkEwkRpXugGAXuLTEPXtaZVsWELK3TokkF0lmKMrN4A\
-DRw9UBahxgaQ5oO1bo6XBwSFQx5by3vhYkIjAKCCtbVgeJ+Mn+\
-ayFQMwISukEYTqDmxBy8NiyoEUCGQNJSr09tPYHAlxbi0G8nR3MH8W0onoV0luKwjaRjcG+\
-WWRea8K0JdYSSPEghDIaSpRpca5T4BZaGuDtlIiDoGyyzHkEEbiJ0QUfAUSidUxDSM4mpTRSipStTx\
-83nHO4CSMGNGebuuQxGJqgSxd72mZnvKOkQMgZFWYMzlsL2sa1RUkiLxDC5rTxpagqy0lOktWQeNuB\
-YF5WEEiW8NedQ2absiD6sJqBrcobgkCGnA8G9WtDchDkMg74TEY6WWxzKjcvQWD8gJiJGLUWUg00IG\
-VgaTCJGJNxLAEFSFiH+\
-Dot4D5eE4hVAc1lJEpxvXtkewpiQNaJfHVevEYVWOyRIL5eAnZE2XMJeYK1fRjUQ9LkuYsjWWk9y4b\
-IC0jagQY/T12l90z+yM+jPhQ/ZKSJRgSEOJTBuZtL+7I6gpGkKvvEzpgh81MZr2o88x+\
-p2femGDLkqykbYsvUSnrQ7JigKjBPYotO2wk66iYo+ryOVyZ//M01bibDObq2iz2+\
-MhnOOng82oXFlUUsSATcgB8nO66OdfCdj4rU8/vJ1+9X2TKuNROsHkhJoU/\
-ao76rGdn3pt87aAc76MklPv3WcftFfxS/ZJXa6huF0p5zOgrPEZJfb5iJJS0xIX07zn0E/SJrKTo/\
-T7husENi3xMUs+3rtHDdjk73r54IgJ6k0pp//8h+328TnzE6V3FTEljzDz9/\
-T81xIKm0I9XTvp98quLzC+4XuA8SXfmInbeZfrWNwu7zqVaM2Z7/WZNQzE/y5gy/LV9Lt+/+\
-kcPgPS4jd7Jrba+bFf1m+1zzdW8estdn0H3/72Fjue8bpNK+l35MXfMn6oGwlMb+RtxvtWuAS7Uzh/\
-/Kk77fz4gWCrbB/P/cPn5/7j+sNnD6fs+KaFZ1N2/Jzn9nGe28957h8+H/dfznrlvc+PP0tpxo++\
-f4DSOT+68hGl83nu85Muj9ubs3FPrvS4i82oHe9iwB7/k+nY4+89yBx25UtROx/Yc2QwYJMff+\
-7jhwLO8XkbVMvotB99ntHf/Wj/Pkpnr9+g8TNTMbtBnOeAp727t9kN4jw3OGd83gZ9dJnSP/3oRz+\
-k9K4fPcTowvUbNHGmjYXaxOWn2bkwHWphAC89+D4LZd4//pseyFYE3N4zVz8bn7dBtzN6x4/+\
-eIrSW4sYcuMXAkMU0ORfZ5LMoKMPsJX66fij2M4vO/wSO525/\
-DNfXrMj4Byft0GHnqJEIu0ORn9ZzJC7+A/dbhDnOeAJ4YhsN4jz3OCc8XkbtJXRv/zo+\
-econfejXYwWIeSmY5+wFQi8+NoYA1zzGANYF9nBrjTef3flnQYz4Og7Q3P1s/\
-F5G7SG0TmbQc2M3lqEFTrQwu7Y6R3m9RGOHDJX5oVA1M67Dv2bHQpcfrJ87dcCzvF5G2SeBWf8CDA6\
-67d21Z+v36BAqnvUbhDnOeBjb3Ygu0Gc5wbnjM/boC2MyOF2HyPy8HzyB5QW4x46fImtQOC2I+\
-yU29v2AdtLrm1u80lm9U/+bBs75aaXT43M1c/G39SQ82QNotZ4qTWTo6Z7x5+4zNA1PbKbuf/EB/\
-1awNa/N3h6R8Apf8vRZ6Lft5vdHOETWxnKcPQPwL4bXA/3hAJO+Zv6qJkTfdWj5svkq08wtJPf+\
-r15oT/Wyax55puvM37yyTfMl4xd/pajnxZnHqBofBcbzEh59ccMZVP3FIsk3+mjjB/Dr7I1yZG/\
-qbf7XOgndrUyX05Onae7d+Lc6hbGHxv8rnneVm1aT79Tf3uJ3Xw58rce/YeQoRwy9tHvweqyYcbr/\
-3mXnUX737+bfXv0V0z0dvlYqSPvUdGOdSgZ/TQbEHRnmr3tY+Tf+\
-pmsk5VY6RClkWGkJdWoI7FSHEJiwpltKWeNA7I0gp15mE9jHmQOcLMRBVdm5KqCohSHPF3i9FUlMJC\
-sb1B7VT1p8M6SbGbNk10HK5p4PjHbw/\
-OJS4T1xJFrfQL4jJUw6zVgol1VNTMfCTwXvzORlXdmAK0JwQphk6bEyJo0BuOi0R0eCCvJYVm9XzYE\
-4BF8gnOcBQ14hV+\
-9IICNccPQ8drGRmQl8nBDypxOUrRktEHSEo1hUVKg0Q91DcuGhtJZ2cb5VIPKnrQOkSKrI4P9faCcO\
-KETxsSkkk2bUmNt3igSBGdXPi6kKcO8XUjkTVtyVRGpPc/npW+p0AmxRCKATp6/2kahIykrUZ/\
-O3IN9MQ35LI/5ZNW3PYkNn+\
-iLwZSPOAziedCxAFxmRdqs7CSXAKXknEomVJzJ8lpf8hPGsmJeYuRsmTmSpOW0qRMSr0HnblhqgWEw\
-bTvr6lhm68kfENcK6FmrDuO8tQaLFq7Mllv2Os7YWhDXUvQ8UIfJYiJRorlhp4sq1icTEYjWiWhkVl\
-91mIw1wghKMqaHlSe7ymzqtGqIY0z3rKE3OAw8A5r+6Q2AZXRN6E4J0wPJLCCYC+\
-y233WsenBLqh5BRcPXXPVw3s6Fskeh7FEoexTKHoWyR6HsUSh7FMoe17ZChbJHoexRKHsUyh6Fskeh\
-7FEoexTKHoWyR6HssXhlj7JC2aNQ9rhBZY+\
-roqsU7ofplIaieCFBNU94WZEM3PeQKLpHAGWChVgAxUJf3zoB3CH0iWgY+\
-hRRHU6SveVLaFGoEPReob2XDjCjgTTU8LHcAwJZCfo/\
-4qlcDbFnk2zEAdRFxDK1uBjENZQbKcCVlwtqhE5NStKsrbigJZpvk2wWbsz+\
-uFkb7xpcWCtsQDKZTFR8/VCBIl7A/qoSVjX72nXka25qbhGubQH7yBKQ/\
-TCoR8lfbqbqCmEjRHhBG7tUWNXQ1NB8TeqWCIODvZ356/\
-qiIEba2tasamupXxVpaa5f3dom1t8baYH1UalVksSo1NbUfO9cUAr10kK9tFAvvWq9NPtmdZYi53hE\
-2qYHldaOo0VUJeYodt6W86tw5iOVlymBexvR6vh1uvaSeuClL0Pw2fkOeSJAzw5Ql8+\
-JUA8quQJqFSgxb5V6UGodd6CYHWL1oML2uAH1C3qy1IPl2WuqTzNf38Q2D72EWvlVl0qlZl9yWmR79\
-l5LYxIQjaIuNxJM2UAyf6tPjCizAmlJV1Ses2O5OYa+LILknxAk0rFZCf8/0ly74Q=="}, 
-                    "ClickToCopyTemplate"]}}, 
-                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {Automatic, Automatic, Fit}, 
-                    "Rows" -> {{Automatic}}}], "Grid"], FontColor -> 
-                   GrayLevel[0.5], FontSize -> 12, StripOnInput -> False]}}, 
-                GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
-                False, GridBoxDividers -> {
-                 "Columns" -> {{None}}, "RowsIndexed" -> {-1 -> GrayLevel[
-                    Rational[239, 255]]}}, 
-                GridBoxItemSize -> {
-                 "Columns" -> {Automatic, Fit}, "Rows" -> {{Automatic}}}, 
-                GridBoxSpacings -> {
-                 "Columns" -> {1, {}, 1}, "Rows" -> {1, {}, 2}}], "Grid"], 
-              ImageMargins -> 0]}}, 
-           GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> False, 
-           GridBoxBackground -> {"Columns" -> {{Automatic}}}, 
-           GridBoxItemSize -> {
-            "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-           GridBoxSpacings -> {"Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
-           BaselinePosition -> {1, 1}]}, 
-        Dynamic[
-         CurrentValue[
-          EvaluationCell[], {TaggingRules, "StripeOpen"}, False]], Alignment -> 
-        Automatic, ImageSize -> Automatic, ImageMargins -> 0, BaseStyle -> {},
-         DefaultBaseStyle -> "OpenerView", BaselinePosition -> Baseline], 
-       Deployed -> False, StripOnInput -> False], 
-      OpenerView[{
-        Grid[{{
-           Style[
-            Dynamic[
-             DateString[
-              TimeZoneConvert[
-               DateObject[
-               3.890324912210944`16.342560863413077*^9, TimeZone -> 0]], {
-              "MonthName", " ", "DayShort", ", ", "Year", " ", "Hour12Short", 
-               ":", "Minute", " ", "AMPMLowerCase"}], SingleEvaluation -> 
-             True, Evaluator -> "System"], FontSlant -> Italic, FontColor -> 
-            GrayLevel[0.5], FontSize -> 0.9 Inherited], "   ", 
-           Item[
-            Style[
-             Grid[{{
-                Annotation[
-                 Grid[{{
-                    Style["\[Checkmark]", FontColor -> RGBColor[0, 
-                    Rational[2, 3], 0], FontSize -> 16, FontWeight -> 
-                    "Heavy"], "", "Your paclet resource is being published"}},
-                   Alignment -> {Left, Baseline}, 
-                  Spacings -> {{0.25, 2 -> 0.1}, Automatic}], 
-                 DefinitionNotebookClient`Stripes`PackagePrivate`$stripeText[
-                 "Your paclet resource is being published"]], ""}}, Spacings -> 
-              0.25, Alignment -> {Automatic, Baseline}], LineBreakWithin -> 
-             Automatic, LineIndent -> 0], ItemSize -> Fit], 
-           Item[
-            Style["", LineBreakWithin -> Automatic, LineIndent -> 0], 
-            ItemSize -> Fit], 
-           Style[
-            ActionMenu[
-             Highlighted[
-              Row[{
-                Grid[{{
-                   RawBoxes[
-                    TemplateBox[{
-                    TemplateBox[{
-                    PaneBox[
-                    TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, "HintPodIconHint"],
-                     ImageSize -> {12, 12}, ImageSizeAction -> "ShrinkToFit", 
-                    BaselinePosition -> Scaled[0.1]], 
-                    TemplateBox[{1}, "Spacer1"], 
-                    StyleBox[
-                    "3", FontSize -> 14, FontWeight -> Plain, FontColor -> 
-                    GrayLevel[0.25], FontFamily -> "Source Sans Pro", 
-                    StripOnInput -> False]}, "RowDefault"], 
-                    "\"Potential issues found\""}, 
-                    "PrettyTooltipTemplate"]]}}], 
-                Graphics[{
-                  GrayLevel[0.4], 
-                  AbsoluteThickness[2], 
-                  CapForm["Round"], 
-                  Line[{{-1, 0}, {0, -1}, {1, 0}}]}, {
-                 ImageSize -> {13, 9}, BaselinePosition -> Scaled[0.2], 
-                  ImagePadding -> {{3, 3}, {3, 3}}, AspectRatio -> Full}]}], 
-              ImageSize -> {Automatic, 19}, BaselinePosition -> Baseline, 
-              Background -> GrayLevel[1], Frame -> True, FrameStyle -> Dynamic[
-                If[
-                 CurrentValue["MouseOver"], 
-                 Hue[0.55, 0.82, 0.87], 
-                 GrayLevel[0.8]]], FrameMargins -> {{4, 4}, {1, 1}}, 
-              Alignment -> {Center, Baseline}], {Row[{
-                 Pane[
-                  RawBoxes[
-                   TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, 
-                    "HintPodIconHint"]], ImageSize -> {10, 10}, 
-                  ImageSizeAction -> "ShrinkToFit", BaselinePosition -> 
-                  Scaled[0.1]], " ", 
-                 "New submissions should typically be version 1.0.0"}] :> 
-              DefinitionNotebookClient`WithCurrentNotebook[
-                EvaluationNotebook[], 
-                DefinitionNotebookClient`LoadDefinitionNotebook[
-                 "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                DefinitionNotebookClient`PackageScope`setHint[
-                 "Warning", "Paclet", 
-                  DefinitionNotebookClient`$CurrentNotebook, 
-                  "aed155fd-a858-451b-81e5-cdfd55e71bc6", 22849867, 
-                  "InvalidFirstVersion", <|
-                  "Current" -> "1.0.2", "Published" -> None, 
-                   "Selection" -> ("Version" -> "1.0.2"), "PublisherID" -> 
-                   "Wolfram", "PacletDirectory" -> 
-                   File["/Users/christopher/git/ChatGPTPluginKit/\
-ChatGPTPluginKit"], "ResourceName" -> "Wolfram/ChatGPTPluginKit"|>]; 
-                DefinitionNotebookClient`PackageScope`seekAfter[22849867]; 
-                Null], Row[{
-                 Pane[
-                  RawBoxes[
-                   TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, 
-                    "HintPodIconHint"]], ImageSize -> {10, 10}, 
-                  ImageSizeAction -> "ShrinkToFit", BaselinePosition -> 
-                  Scaled[0.1]], " ", 
-                 "This cell has excessive height. Consider reducing the size \
-to avoid potential issues."}] :> 
-              DefinitionNotebookClient`WithCurrentNotebook[
-                EvaluationNotebook[], 
-                DefinitionNotebookClient`LoadDefinitionNotebook[
-                 "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                DefinitionNotebookClient`PackageScope`setHint[
-                 "Warning", "Paclet", 
-                  DefinitionNotebookClient`$CurrentNotebook, 
-                  "647f617d-bc8f-4ba6-bcc2-832c3c12b13c", 1822574373, 
-                  "LargeCellBounds/CellHeight", <|
-                  "Type" -> "height", "CellID" -> 1822574373, "CellObject" -> 
-                   CellObject[
-                    "9632ecf7-afa9-422e-926c-8cb13c53fac8", 
-                    "a4bf90e3-d762-4a14-97d1-38e91da04ee6"], 
-                   "CellSerialNumber" -> 67522, "CellSize" -> {298, 531}, 
-                   "CellTags" -> {}, "ContentData" -> BoxData, 
-                   "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                   None, "Evaluatable" -> False, "Evaluating" -> False, 
-                   "ExpressionUUID" -> "9632ecf7-afa9-422e-926c-8cb13c53fac8",
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                   "NeedsRendering" -> False, "Position" -> 51, "Rendering" -> 
-                   False, "Style" -> "ExampleImage", "TemplateGroup" -> False,
-                    "TemplateGroupName" -> None, "Area" -> 500000., "Height" -> 
-                   500., "Width" -> 2000|>]; 
-                DefinitionNotebookClient`PackageScope`seekAfter[1822574373]; 
-                Null], Row[{
-                 Pane[
-                  RawBoxes[
-                   TemplateBox[{
-                    RGBColor[1., 0.4627450980392157, 0.]}, 
-                    "HintPodIconHint"]], ImageSize -> {10, 10}, 
-                  ImageSizeAction -> "ShrinkToFit", BaselinePosition -> 
-                  Scaled[0.1]], " ", 
-                 "This cell has excessive height. Consider reducing the size \
-to avoid potential issues."}] :> 
-              DefinitionNotebookClient`WithCurrentNotebook[
-                EvaluationNotebook[], 
-                DefinitionNotebookClient`LoadDefinitionNotebook[
-                 "Paclet", DefinitionNotebookClient`$CurrentNotebook]; 
-                DefinitionNotebookClient`PackageScope`setHint[
-                 "Warning", "Paclet", 
-                  DefinitionNotebookClient`$CurrentNotebook, 
-                  "04ae0cf3-7e8d-44c3-b536-66e3f24bcca1", 1491546085, 
-                  "LargeCellBounds/CellHeight", <|
-                  "Type" -> "height", "CellID" -> 1491546085, "CellObject" -> 
-                   CellObject[
-                    "a066330f-e087-46ff-95e8-20a72804c260", 
-                    "02f91343-4bd5-4cb9-945c-b7c08fa9e2d4"], 
-                   "CellSerialNumber" -> 67530, "CellSize" -> {316, 546}, 
-                   "CellTags" -> {}, "ContentData" -> BoxData, 
-                   "ContentDataForm" -> StandardForm, "CursorPosition" -> 
-                   None, "Evaluatable" -> False, "Evaluating" -> False, 
-                   "ExpressionUUID" -> "a066330f-e087-46ff-95e8-20a72804c260",
-                    "FirstCellInGroup" -> False, "Formatted" -> True, 
-                   "NeedsRendering" -> False, "Position" -> 59, "Rendering" -> 
-                   False, "Style" -> "ExampleImage", "TemplateGroup" -> False,
-                    "TemplateGroupName" -> None, "Area" -> 500000., "Height" -> 
-                   500., "Width" -> 2000|>]; 
-                DefinitionNotebookClient`PackageScope`seekAfter[1491546085]; 
-                Null]}, Appearance -> None], "BoxID" -> "WarningCountButton"], 
-           MouseAppearance[
-            Button[
-             MouseAppearance[
-              Mouseover[
-               Graphics[{
-                 GrayLevel[
-                  Rational[64, 85]], 
-                 
-                 Polygon[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                  0.42426406871192845`}, {0.42426406871192845`, 
-                  0.282842712474619}}], 
-                 
-                 Polygon[{{0.42426406871192845`, -0.282842712474619}, {
-                  0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                  0.42426406871192845`}}]}, ImageSize -> 18, PlotRangePadding -> 
-                0, PlotRange -> 0.7, Background -> None], 
-               Graphics[{
-                 GrayLevel[
-                  Rational[128, 255]], 
-                 
-                 Polygon[{{-0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, -0.282842712474619}, {0.282842712474619, 
-                  0.42426406871192845`}, {0.42426406871192845`, 
-                  0.282842712474619}}], 
-                 
-                 Polygon[{{0.42426406871192845`, -0.282842712474619}, {
-                  0.282842712474619, -0.42426406871192845`}, \
-{-0.42426406871192845`, 0.282842712474619}, {-0.282842712474619, 
-                  0.42426406871192845`}}]}, ImageSize -> 18, PlotRangePadding -> 
-                0, PlotRange -> 0.7, Background -> None]], "LinkHand"], 
-             
-             With[{DefinitionNotebookClient`Stripes`PackagePrivate`nbo$ = 
-               EvaluationNotebook[]}, 
-              CurrentValue[
-               DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                DockedCells] = If[
-                TrueQ[
-                 MemberQ[
-                  CurrentValue["ModifierKeys"], "Control"]], 
-                DeleteCases[
-                 Flatten[{
-                   CurrentValue[
-                   DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                 Cell[
-                  Blank[], "StripeCell", 
-                  BlankNullSequence[]]], 
-                DeleteCases[
-                 Flatten[{
-                   CurrentValue[
-                   DefinitionNotebookClient`Stripes`PackagePrivate`nbo$, 
-                    DockedCells]}], 
-                 Condition[
-                  Pattern[
-                  DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                   Blank[Cell]], 
-                  Not[
-                   FreeQ[
-                   DefinitionNotebookClient`Stripes`PackagePrivate`c$, 
-                    "a644fe0b-77e5-44a5-8592-6b8ec3dde629"]]]]]], Appearance -> 
-             None, BoxID -> "a644fe0b-77e5-44a5-8592-6b8ec3dde629"], 
-            "LinkHand"]}}, Alignment -> {Left, Baseline}], 
-        Grid[{{"", 
-           Style[
-            Grid[{{"\[FilledVerySmallSquare]", "Submission result:", 
-               RawBoxes[
-                TemplateBox[{
-                  TagBox[
-                   RowBox[{
-                    TagBox["Success", "SummaryHead"], "[", 
-                    
-                    DynamicModuleBox[{
-                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-                    TemplateBox[{
-                    PaneSelectorBox[{False -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxOpener"]], 
-                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    FrameBox[
-                    StyleBox["\"\[Checkmark]\"", 
-                    Directive[
-                    RGBColor[
-                    0.3607843137254902, 0.596078431372549, 
-                    0.3803921568627451], 25], StripOnInput -> False], 
-                    ContentPadding -> False, FrameStyle -> None, 
-                    FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"Your paclet resource is being published\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Name\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Wolfram/ChatGPTPluginKit\"", "SummaryItem"]}]}},
-                     GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}], True -> GridBox[{{
-                    PaneBox[
-                    ButtonBox[
-                    DynamicBox[
-                    FEPrivate`FrontEndResource[
-                    "FEBitmaps", "SummaryBoxCloser"]], 
-                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
-                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
-                    Dynamic[{Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], 
-                    FrameBox[
-                    StyleBox["\"\[Checkmark]\"", 
-                    Directive[
-                    RGBColor[
-                    0.3607843137254902, 0.596078431372549, 
-                    0.3803921568627451], 25], StripOnInput -> False], 
-                    ContentPadding -> False, FrameStyle -> None, 
-                    FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
-                    
-                    GridBox[{{
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"Your paclet resource is being published\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Name\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Wolfram/ChatGPTPluginKit\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"UUID\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    "\"ab885183-1b32-478a-9b3e-dc7ccadc8029\"", 
-                    "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"ResourceType\"", "\": \""}, "RowDefault"],
-                     "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"Paclet\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Warnings\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox[
-                    RowBox[{"{", "}"}], "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Version\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"1.0.2\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"SubmissionID\"", "\": \""}, "RowDefault"],
-                     "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"8697\"", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    
-                    TemplateBox[{"\"DirectCreation\"", "\": \""}, 
-                    "RowDefault"], "SummaryItemAnnotation"], 
-                    "\[InvisibleSpace]", 
-                    TagBox["True", "SummaryItem"]}]}, {
-                    RowBox[{
-                    TagBox[
-                    TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
-                    "SummaryItemAnnotation"], "\[InvisibleSpace]", 
-                    TagBox["\"ResourceSubmission\"", "SummaryItem"]}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
-                    BaseStyle -> {
-                    ShowStringCharacters -> False, NumberMarks -> False, 
-                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
-                    False, GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    BaselinePosition -> {1, 1}]}, 
-                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
-                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
-                   Short[#, 0.75]& ], 
-                  "OEM6eJztWE1vG0UYjuNvx3VDGwT0FK0iUA8uTQLE4RKcTZxGNKnlcRsQQup\
-497U9Ynd2NTOb1CB+AieuHPhXcIYfwE+Ad/bDdjaJFBxXcPBedjXv1zPvt7afkaUOvdj33oDs5+\
-U7x1yB8AUoqpjH8bifkYWOpxn6OZl7zqTqL8tClw7whBRJYFkgJVkhgetSMXoG1CaZb/\
-pZuXow4tRl1olnBw5o8eWxeJaAkrXuyAcJ6rXnA9/\
-YkPkWdSQk1LWECm4PbIJwYGOD5Duof4Q8K11wfQcPI4SR4qy836YcCDhgKU9ctpnrIIzESF4WjwSzL\
-wsn76JWokkFWd4PlErcUIlvFOl91DpsC3aOEF63hMfVIbc7IL1AWEDKrcN9plzqS7IaOwaFXuA9QWj\
-wGsoBOHQEtqxFJloBt7THb/JOrisCGF+j0vR9oIJydH7u1OMTSnmfSiBq5EB/\
-KXX38uE5dQKKnpHlZqA8F0NsjamFE1BDzyaVtgD0rWLnU0qbDhtwF7hKHCoLJuhMSd4T1mOXDoCw7w\
-E9Vow9Npa6ZDffZS5IsRQ+1S/GJyhYNQMhUPErBAzkXgv9a1L/GbDBUEPIt70LtJmRa82e9JxAwTS/\
-vHdCB5z1mRXmsPk3hrvUEtQNg5qVpdA9On3zxh+//GygwvIBE5gz+s5I7xztm57jCfFe+\
-Py2Jx6Gz5974qvw+X3P/GB84ypRgvkv+\
-DH3AzXJ4ohYMxE6AmtT22Z8kCZXQlghnlQcqyHlhIoB43I6jfXbXDKX0t83YylMkj3Rkxm/\
-k9rOpms7XWSxKCkbJ1jwGGOD5IzP1w1SQQ0H0KeBo8i7cbYfK3CbnHtRFyHZv376daprPDa+\
-xjpZ96nlgFoXcdWsM7neA3TSuh/0HCaHYBvjvqIV3gV1wThFd84O+\
-ZFx5jl9DMnH5pCqo3a37QQYmS+ZSmFMIrEau/xK5SQcpIg5FrhcTl0rKpLcc+\
-hP2HKI9SrPNQVc0UfYVUBBOs3ux2A0wrA0b43lqp3bA0qsEgy0zv1bWzWX/72xqb6XS/\
-W9NTL0LnRh8AEGT1BL9620i1ZOAxw0Agvuuyu0GjZ6LGHsEEzqhpKdRDlUPeKKvomKOC36ltMg2/\
-X8/28CrOqYOIxD25MsHm5RgDNmZswVTbb/ZCKbjidnnsjpVr4YyYuRPMNILi9G8lseyXfC+\
-PLl8cHsGD80aK/R+HSzsV3f7G1v1T/\
-ZadD6bm8b6ra1Y1nUthpPt3bnh7dmJB1PN6vZcZeMdpgJ80NWMc6o4LreZkY1ZTbRmvmBZH6cG8ay8\
-QrbJxqe3XFFY/PJ0ydb84woCXoukxrWXTKxYDQ+292ZH65VI+rPpoDQ3uzIwvk/N1x5A+\
-mzg1kbF9DE7YsNf7HhLzb8GTb8ybaZXp6v2U2n1JNqXG967XfS6/nDSz8Wo/UyWaxJ5ltkH/+\
-VfHC1mJulOinG6xL56JZLT53k9K5C3r9p40AGvSiQjduM+\
-zqpTk9pUohmbZ2UkhGZXAehxhOJ5MO5UteumYwDktNNvU5ql3tx+\
-mdh9EOU9pwrWVM6tNm1hAeRzBlTw3hdlpHWfwC2bII3"}, "ClickToCopyTemplate"]]}, {
-              "\[FilledVerySmallSquare]", "Resource object:", 
-               RawBoxes[
-                TemplateBox[{
-                  TagBox[
-                   RowBox[{"ResourceObject", "[", 
-                    ButtonBox[
-                    TagBox[
-                    GridBox[{{
-                    GraphicsBox[{
-                    Thickness[0.0025], {
-                    FaceForm[{
-                    RGBColor[
-                    0.9607843137254902, 0.5058823529411764, 
-                    0.19607843137254902`], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {1, 3, 3}, {0, 1, 
-                    0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
-                    3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
-                    3}}}, {{{205., 22.660200119018555`}, {205., 
-                    212.11320304870605`}, {246.01799774169922`, 
-                    235.79520988464355`}, {369.0710144042969, 
-                    306.8401927947998}, {369.0710144042969, 
-                    117.38719749450684`}, {205., 22.660200119018555`}}, {{
-                    30.928985595703125`, 306.8401927947998}, {
-                    153.98200225830078`, 235.79520988464355`}, {195., 
-                    212.11320304870605`}, {195., 22.660200119018555`}, {
-                    30.928985595703125`, 117.38719749450684`}, {
-                    30.928985595703125`, 306.8401927947998}}, {{200., 
-                    410.22620964050293`}, {364.0710144042969, 
-                    315.5001964569092}, {241.01799774169922`, 
-                    244.45519828796387`}, {200., 220.77320671081543`}, {
-                    158.98200225830078`, 244.45519828796387`}, {
-                    35.928985595703125`, 315.5001964569092}, {200., 
-                    410.22620964050293`}}, CompressedData["
-1:eJxTTMoPSmViYGCQAWIQDQQPlDrLHYB0n8ffYgewSEAmhO9aBaJ/1cmB+XqT
-gsF8tsaHGch8BoYNGcjqGS7lmqOYd/qhKYg+9+8dhH/prQmI9ptyBYV/jmEH
-Cj+CeUEMMr9iq24MsnkV3Eeike2b8aQrGtk9DSrhyiA6e88JMD/BvUgJbG/S
-EzBfQYpBCaKeIROZv2muNDK/YaqzeSayflj4wMyHhR/M/oDHC8uR3fdAaWM5
-svthfJj/YHyY/2F8WPjAzIOFH0p8AQA7u3Ea
-                    "]}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{43., 198.67381286621094`}, {107.71399688720703`, 
-                    161.3118133544922}, {107.71399688720703`, 
-                    86.58680725097656}, {43., 123.94882202148438`}, {43., 
-                    198.67381286621094`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.3137254901960784, 0.4549019607843137, 
-                    0.611764705882353], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{182.77679443359375`, 198.67381286621094`}, {
-                    182.77679443359375`, 123.94882202148438`}, {
-                    118.06279754638672`, 86.58680725097656}, {
-                    118.06279754638672`, 161.3118133544922}, {
-                    182.77679443359375`, 198.67381286621094`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.7803921568627451, 0.8627450980392157, 
-                    0.9490196078431372], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{112.8884048461914, 244.9990997314453}, {
-                    177.60240173339844`, 207.63610076904297`}, {
-                    112.8884048461914, 170.27410888671875`}, {
-                    48.174407958984375`, 207.63610076904297`}, {
-                    112.8884048461914, 244.9990997314453}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{130.02911376953125`, 350.11590576171875`}, {
-                    194.80210876464844`, 312.7189064025879}, {
-                    194.80210876464844`, 237.92591094970703`}, {
-                    130.02911376953125`, 275.32291412353516`}, {
-                    130.02911376953125`, 350.11590576171875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.4627450980392157, 0.3607843137254902, 
-                    0.611764705882353], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{269.9334716796875, 350.11590576171875`}, {
-                    269.9334716796875, 275.32291412353516`}, {
-                    205.1604766845703, 237.92591094970703`}, {
-                    205.1604766845703, 312.7189064025879}, {269.9334716796875,
-                     350.11590576171875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.8862745098039215, 0.803921568627451, 
-                    0.9529411764705882], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{199.98130798339844`, 396.48345947265625`}, {
-                    264.7543029785156, 359.0864601135254}, {
-                    199.98130798339844`, 321.69046783447266`}, {
-                    135.20831298828125`, 359.0864601135254}, {
-                    199.98130798339844`, 396.48345947265625`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{217.61199951171875`, 199.13890075683594`}, {
-                    281.8990020751953, 162.0229034423828}, {281.8990020751953,
-                     87.7908935546875}, {217.61199951171875`, 
-                    124.90690612792969`}, {217.61199951171875`, 
-                    199.13890075683594`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.43137254901960786`, 0.6039215686274509, 
-                    0.34509803921568627`], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{356.46661376953125`, 199.13890075683594`}, {
-                    356.46661376953125`, 124.90690612792969`}, {
-                    292.1796112060547, 87.7908935546875}, {292.1796112060547, 
-                    162.0229034423828}, {356.46661376953125`, 
-                    199.13890075683594`}}}]}, {
-                    FaceForm[{
-                    RGBColor[0.8549019607843137, 0.9450980392156862, 0.8], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
-                    0}}}, {{{287.039306640625, 245.15859985351562`}, {
-                    351.32630920410156`, 208.0426025390625}, {
-                    287.039306640625, 170.92660522460938`}, {
-                    222.75230407714844`, 208.0426025390625}, {
-                    287.039306640625, 245.15859985351562`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    356.46649169921875`, 215.76849365234375`}, {
-                    296.2834930419922, 250.5924949645996}, {
-                    356.46649169921875`, 285.26649475097656`}, {
-                    356.46649169921875`, 215.76849365234375`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6627450980392157, 0.803921568627451, 
-                    0.5686274509803921], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    217.61199951171875`, 114.06449890136719`}, {
-                    277.7949981689453, 79.24049758911133}, {
-                    217.61199951171875`, 44.566497802734375`}, {
-                    217.61199951171875`, 114.06449890136719`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    122.17269897460938`, 78.36309814453125}, {
-                    182.42269897460938`, 113.07109832763672`}, {
-                    182.35969924926758`, 43.614097595214844`}, {
-                    122.17269897460938`, 78.36309814453125}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.5529411764705883, 0.6745098039215687, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    103.52159881591797`, 249.46669006347656`}, {
-                    43.27159881591797, 214.7586898803711}, {
-                    43.334598541259766`, 284.21569061279297`}, {
-                    103.52159881591797`, 249.46669006347656`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    120.86710357666016`, 350.61541748046875`}, {
-                    120.80010357499123`, 281.0834197998047}, {
-                    60.68010330200195, 315.86641693115234`}, {
-                    120.86710357666016`, 350.61541748046875`}}}]}, {
-                    FaceForm[{
-                    RGBColor[
-                    0.6901960784313725, 0.5882352941176471, 
-                    0.8117647058823529], 
-                    Opacity[1.]}], 
-                    
-                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{
-                    278.3727111816406, 281.2159118652344}, {
-                    278.43971118330956`, 350.74790954589844`}, {
-                    338.5597114562988, 315.9649124145508}, {278.3727111816406,
-                     281.2159118652344}}}]}}, {
-                    ImageSize -> 12, BaselinePosition -> Scaled[0.1], 
-                    ImageSize -> {Automatic, 35}}], 
-                    StyleBox[
-                    "\"Wolfram/ChatGPTPluginKit\"", FontFamily -> Dynamic[
-                    CurrentValue["PanelFontFamily"]], FontSize -> 
-                    0.8 Inherited, ShowStringCharacters -> False, 
-                    StripOnInput -> False]}}, 
-                    GridBoxAlignment -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Baseline}}}, 
-                    AutoDelete -> False, 
-                    GridBoxItemSize -> {
-                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-                    GridBoxSpacings -> {
-                    "Columns" -> {{0.25}}, "Rows" -> {{0}}}], "Grid"], 
-                    ButtonFunction :> {}, Evaluator -> None, Active -> False, 
-                    Alignment -> Left, 
-                    Appearance -> {
-                    "Default" -> 
-                    FrontEnd`FileName[{"Typeset", "SummaryBox"}, 
-                    "Panel.9.png"]}, FrameMargins -> {{3, 3}, {3, 0}}, 
-                    BaseStyle -> {Deployed -> False}, 
-                    DefaultBaseStyle -> {Background -> None}, 
-                    BaselinePosition -> Baseline, Method -> "Preemptive"], 
-                    "]"}], Short[#, 0.75]& ], 
-                  "OEM6eJztW31sFMcVv/\
-OdbfwJJm7SkrQ6LVaVVvEHNtQOUnNnn322FQMnjw0kQOq9vTnf4r3dZWbP56MSchtUKU1KaIGGpg0x\
-balS/qgIUiXybZpWaRU1lShtrdI2dghRURpAVZISlDadmd2521vb4gwG8sc9IS9v5s2833vz5oP3cM\
-yNl/SLqQ5tDOJYMa7pVQ2IdAQN0ZA1lTTH3LikX6MCMS/\
-29snYiBXhkgFxmLSA6n6ItSSS4IbIdigZoAIkEwkRpXugGAXuLTEPXtaZVsWELK3TokkF0lmKMrN4A\
-DRw9UBahxgaQ5oO1bo6XBwSFQx5by3vhYkIjAKCCtbVgeJ+Mn+\
-ayFQMwISukEYTqDmxBy8NiyoEUCGQNJSr09tPYHAlxbi0G8nR3MH8W0onoV0luKwjaRjcG+\
-WWRea8K0JdYSSPEghDIaSpRpca5T4BZaGuDtlIiDoGyyzHkEEbiJ0QUfAUSidUxDSM4mpTRSipStTx\
-83nHO4CSMGNGebuuQxGJqgSxd72mZnvKOkQMgZFWYMzlsL2sa1RUkiLxDC5rTxpagqy0lOktWQeNuB\
-YF5WEEiW8NedQ2absiD6sJqBrcobgkCGnA8G9WtDchDkMg74TEY6WWxzKjcvQWD8gJiJGLUWUg00IG\
-VgaTCJGJNxLAEFSFiH+\
-Dot4D5eE4hVAc1lJEpxvXtkewpiQNaJfHVevEYVWOyRIL5eAnZE2XMJeYK1fRjUQ9LkuYsjWWk9y4b\
-IC0jagQY/T12l90z+yM+jPhQ/ZKSJRgSEOJTBuZtL+7I6gpGkKvvEzpgh81MZr2o88x+\
-p2femGDLkqykbYsvUSnrQ7JigKjBPYotO2wk66iYo+ryOVyZ//M01bibDObq2iz2+\
-MhnOOng82oXFlUUsSATcgB8nO66OdfCdj4rU8/vJ1+9X2TKuNROsHkhJoU/\
-ao76rGdn3pt87aAc76MklPv3WcftFfxS/ZJXa6huF0p5zOgrPEZJfb5iJJS0xIX07zn0E/SJrKTo/\
-T7husENi3xMUs+3rtHDdjk73r54IgJ6k0pp//8h+328TnzE6V3FTEljzDz9/\
-T81xIKm0I9XTvp98quLzC+4XuA8SXfmInbeZfrWNwu7zqVaM2Z7/WZNQzE/y5gy/LV9Lt+/+\
-kcPgPS4jd7Jrba+bFf1m+1zzdW8estdn0H3/72Fjue8bpNK+l35MXfMn6oGwlMb+RtxvtWuAS7Uzh/\
-/Kk77fz4gWCrbB/P/cPn5/7j+sNnD6fs+KaFZ1N2/Jzn9nGe28957h8+H/dfznrlvc+PP0tpxo++\
-f4DSOT+68hGl83nu85Muj9ubs3FPrvS4i82oHe9iwB7/k+nY4+89yBx25UtROx/Yc2QwYJMff+\
-7jhwLO8XkbVMvotB99ntHf/Wj/Pkpnr9+g8TNTMbtBnOeAp727t9kN4jw3OGd83gZ9dJnSP/3oRz+\
-k9K4fPcTowvUbNHGmjYXaxOWn2bkwHWphAC89+D4LZd4//pseyFYE3N4zVz8bn7dBtzN6x4/+\
-eIrSW4sYcuMXAkMU0ORfZ5LMoKMPsJX66fij2M4vO/wSO525/\
-DNfXrMj4Byft0GHnqJEIu0ORn9ZzJC7+A/dbhDnOeAJ4YhsN4jz3OCc8XkbtJXRv/zo+\
-econfejXYwWIeSmY5+wFQi8+NoYA1zzGANYF9nBrjTef3flnQYz4Og7Q3P1s/\
-F5G7SG0TmbQc2M3lqEFTrQwu7Y6R3m9RGOHDJX5oVA1M67Dv2bHQpcfrJ87dcCzvF5G2SeBWf8CDA6\
-67d21Z+v36BAqnvUbhDnOeBjb3Ygu0Gc5wbnjM/boC2MyOF2HyPy8HzyB5QW4x46fImtQOC2I+\
-yU29v2AdtLrm1u80lm9U/+bBs75aaXT43M1c/G39SQ82QNotZ4qTWTo6Z7x5+4zNA1PbKbuf/EB/\
-1awNa/N3h6R8Apf8vRZ6Lft5vdHOETWxnKcPQPwL4bXA/3hAJO+Zv6qJkTfdWj5svkq08wtJPf+\
-r15oT/Wyax55puvM37yyTfMl4xd/pajnxZnHqBofBcbzEh59ccMZVP3FIsk3+mjjB/Dr7I1yZG/\
-qbf7XOgndrUyX05Onae7d+Lc6hbGHxv8rnneVm1aT79Tf3uJ3Xw58rce/YeQoRwy9tHvweqyYcbr/\
-3mXnUX737+bfXv0V0z0dvlYqSPvUdGOdSgZ/TQbEHRnmr3tY+Tf+\
-pmsk5VY6RClkWGkJdWoI7FSHEJiwpltKWeNA7I0gp15mE9jHmQOcLMRBVdm5KqCohSHPF3i9FUlMJC\
-sb1B7VT1p8M6SbGbNk10HK5p4PjHbw/\
-OJS4T1xJFrfQL4jJUw6zVgol1VNTMfCTwXvzORlXdmAK0JwQphk6bEyJo0BuOi0R0eCCvJYVm9XzYE\
-4BF8gnOcBQ14hV+\
-9IICNccPQ8drGRmQl8nBDypxOUrRktEHSEo1hUVKg0Q91DcuGhtJZ2cb5VIPKnrQOkSKrI4P9faCcO\
-KETxsSkkk2bUmNt3igSBGdXPi6kKcO8XUjkTVtyVRGpPc/npW+p0AmxRCKATp6/2kahIykrUZ/\
-O3IN9MQ35LI/5ZNW3PYkNn+\
-iLwZSPOAziedCxAFxmRdqs7CSXAKXknEomVJzJ8lpf8hPGsmJeYuRsmTmSpOW0qRMSr0HnblhqgWEw\
-bTvr6lhm68kfENcK6FmrDuO8tQaLFq7Mllv2Os7YWhDXUvQ8UIfJYiJRorlhp4sq1icTEYjWiWhkVl\
-91mIw1wghKMqaHlSe7ymzqtGqIY0z3rKE3OAw8A5r+6Q2AZXRN6E4J0wPJLCCYC+\
-y233WsenBLqh5BRcPXXPVw3s6Fskeh7FEoexTKHoWyR6HsUSh7FMoe17ZChbJHoexRKHsUyh6Fskeh\
-7FEoexTKHoWyR6HssXhlj7JC2aNQ9rhBZY+\
-roqsU7ofplIaieCFBNU94WZEM3PeQKLpHAGWChVgAxUJf3zoB3CH0iWgY+\
-hRRHU6SveVLaFGoEPReob2XDjCjgTTU8LHcAwJZCfo/\
-4qlcDbFnk2zEAdRFxDK1uBjENZQbKcCVlwtqhE5NStKsrbigJZpvk2wWbsz+\
-uFkb7xpcWCtsQDKZTFR8/VCBIl7A/qoSVjX72nXka25qbhGubQH7yBKQ/\
-TCoR8lfbqbqCmEjRHhBG7tUWNXQ1NB8TeqWCIODvZ356/\
-qiIEba2tasamupXxVpaa5f3dom1t8baYH1UalVksSo1NbUfO9cUAr10kK9tFAvvWq9NPtmdZYi53hE\
-2qYHldaOo0VUJeYodt6W86tw5iOVlymBexvR6vh1uvaSeuClL0Pw2fkOeSJAzw5Ql8+\
-JUA8quQJqFSgxb5V6UGodd6CYHWL1oML2uAH1C3qy1IPl2WuqTzNf38Q2D72EWvlVl0qlZl9yWmR79\
-l5LYxIQjaIuNxJM2UAyf6tPjCizAmlJV1Ses2O5OYa+LILknxAk0rFZCf8/0ly74Q=="}, 
-                 "ClickToCopyTemplate"]]}}, Alignment -> Left, 
-             ItemSize -> {{Automatic, Automatic, Fit}, Automatic}], FontColor -> 
-            GrayLevel[0.5], FontSize -> 12]}}, 
-         ItemSize -> {{Automatic, Fit}, Automatic}, Alignment -> Left, 
-         Dividers -> {None, {-1 -> GrayLevel[
-              Rational[239, 255]]}}, Spacings -> {{1, {}, 1}, {1, {}, 2}}]}, 
-       Dynamic[
-        CurrentValue[
-         EvaluationCell[], {TaggingRules, "StripeOpen"}, False]]]], "Text", 
-     FontSize -> 12, FontColor -> GrayLevel[0.25], StripOnInput -> False]], 
-   "StripeCell", CellFrameMargins -> {{20, 5}, {2, 2}}, 
-   CellFrame -> {{0, 0}, {1, 0}}, CellFrameColor -> GrayLevel[0.75]]},
+      EvaluationNotebook[], {TaggingRules, "ToolsOpen"}, True]]]},
 TaggingRules->{"CompatibilityTest" -> HoldComplete[
     BinaryDeserialize[
      BaseDecode[
@@ -11788,7 +9816,7 @@ DmYNiJISfY4v0k4q2S8VhTACISIANQJaQKNqzJr+XvEL8zFNhEaEiBBUI7y0
 RdVaryG+TDK3OwuhFSECs9O1ogBUqqFqLJlZvezJ6iak8ESIwDRCAwpVo2eg
 Ys/3lPk2CI0IEd6AxOSc1BLPvLR8NF0euq8WznkZnobQhRARhOjyTczLTEst
 LsGfv7fu0lLbmC/EDQAXRy8EPc5wRQ==
-      "]]}},
+      "]]}, "TryRealOnly" -> False},
 CreateCellID->True,
 DynamicEvaluationTimeout->60,
 FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
@@ -12113,7 +10141,6 @@ VX/aMEEQzrerjFhhelYAzofFB3r8AgApYdcE
                     15.75, 17.25}, {15.75, 5.25}, {6.75, 5.25}, {6.75, 
                     17.25}, {8.25, 17.25}, {8.25, 18.}}, {{9.75, 17.25}, {
                     12.75, 17.25}, {12.75, 16.5}, {9.75, 16.5}}}], 
-                    
                     FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
                      0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
                     0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{8.25, 
@@ -13358,8 +11385,7 @@ AsyncronousResourceInformationUpdates = False,
              GridBox[{{"\"\"", "\"\""}}, 
               GridBoxAlignment -> {
                "Columns" -> {{Left}}, "Rows" -> {{Center}}}, AutoDelete -> 
-              False, 
-              GridBoxDividers -> {
+              False, GridBoxDividers -> {
                "ColumnsIndexed" -> {2 -> True}, "Rows" -> {{False}}}, 
               GridBoxItemSize -> {
                "Columns" -> {{Automatic}}, "Rows" -> {{2}}}, 
@@ -14500,17 +12526,16 @@ dUs5PEh+6Sx+hd/B9HrmkqVGkvD4AQCmgKFd
          StyleBox[{
            
            FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 
-             1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
-             0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{
-             0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 
-             0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
-             0}}}, {{{5., 12.}, {5., 11.}, {2., 11.}, {2., 12.}}, {{2., 
-             10.}, {2., 9.}, {5., 9.}, {5., 10.}}, {{2., 14.}, {2., 13.}, {5.,
-              13.}, {5., 14.}}, {{2., 8.}, {2., 7.}, {5., 7.}, {5., 8.}}, {{
-             2., 6.}, {2., 5.}, {5., 5.}, {5., 6.}}, {{5., 18.}, {2., 18.}, {
-             2., 17.}, {5., 17.}, {5., 18.}}, {{5., 4.}, {2., 4.}, {2., 3.}, {
-             5., 3.}, {5., 4.}}, {{2., 16.}, {2., 15.}, {5., 15.}, {5., 
-             16.}}}]}, 
+             1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0},
+              {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 
+             2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {
+             0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{5., 
+             12.}, {5., 11.}, {2., 11.}, {2., 12.}}, {{2., 10.}, {2., 9.}, {
+             5., 9.}, {5., 10.}}, {{2., 14.}, {2., 13.}, {5., 13.}, {5., 
+             14.}}, {{2., 8.}, {2., 7.}, {5., 7.}, {5., 8.}}, {{2., 6.}, {2., 
+             5.}, {5., 5.}, {5., 6.}}, {{5., 18.}, {2., 18.}, {2., 17.}, {5., 
+             17.}, {5., 18.}}, {{5., 4.}, {2., 4.}, {2., 3.}, {5., 3.}, {5., 
+             4.}}, {{2., 16.}, {2., 15.}, {5., 15.}, {5., 16.}}}]}, 
           FaceForm[
            RGBColor[0.86667, 0.066667, 0.]]], 
          StyleBox[{
@@ -14961,6 +12986,7 @@ Mn8D1T+bLHr4qqKuQ8bv8LBZfwwdhGSmFwY76zqghzcABAZ3MA==
           FaceForm[
            GrayLevel[1.]]], 
          StyleBox[{
+           
            FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1,
              0}, {0, 1, 0}}}, {{{13., 18.}, {13., 14.5}, {12.99992, 
             14.367367999999999`}, {13.052580000000003`, 14.240146}, {
@@ -17347,7 +15373,8 @@ FpG1n6WfSeLb27c2Volz+/dhBxtxrIPL2Ar/oQtZg16JsQ879Gyxx3vEuygx
              0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
              255, 255}}}], "Byte", ColorSpace -> "RGB", 
             ImageResolution -> {72, 72}, Interleaving -> True], "Pressed" -> 
-          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+          Image[
+           RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
              255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
              0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
              255, 255}}}], "Byte", ColorSpace -> "RGB", 
@@ -18680,6 +16707,7 @@ RefreshNotebookPacletFiles[RSNB`nbo, RSNB`cell]]]],
                     EvaluationCell[], 
                     Cell[
                     BoxData[
+                    
                     TemplateBox[{"\"The current notebook is not saved.\""}, 
                     "PacletDirectoryChooserErrorTemplate"]], 
                     "AttachedMessage"], "Inline", 
@@ -19511,6 +17539,7 @@ GRPf1sw3cDj8VSOm/5G9w5vAHXKt3IZQ/0HDoQHBFwFFwBcEHxR9zQlGcP3o
             FaceForm[{
               RGBColor[0.91, 0.655, 0.635], 
               Opacity[1.]}], 
+            
             FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 
              1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{12.125, 17.763}, {
              11.875, 17.763}, {11.875, 12.041}, {6.952, 9.9757}, {7.048, 

--- a/Notes/chatGPTPluginsAssociations.nb
+++ b/Notes/chatGPTPluginsAssociations.nb
@@ -3,10 +3,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[         0,          0]
-NotebookDataLength[    164329,       3412]
-NotebookOptionsPosition[    159736,       3323]
-NotebookOutlinePosition[    160133,       3339]
-CellTagsIndexPosition[    160090,       3336]
+NotebookDataLength[    198922,       4139]
+NotebookOptionsPosition[    193312,       4033]
+NotebookOutlinePosition[    193709,       4049]
+CellTagsIndexPosition[    193666,       4046]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -2518,15 +2518,14 @@ Cell[BoxData[
         RowBox[{
          RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
          RowBox[{
-          RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}], ",", 
-         RowBox[{"{", 
-          RowBox[{"\"\<WL\>\"", ",", "\"\<HTML\>\""}], "}"}]}], "]"}]}], 
-      "|>"}]}], "|>"}], "]"}]}]], "Input",
+          RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}],
+       "|>"}]}], "|>"}], "]"}]}]], "Input",
  CellChangeTimes->{{3.8903595260944*^9, 3.8903595870661297`*^9}, {
    3.89035994845609*^9, 3.890359949969782*^9}, 3.890359987081604*^9, {
    3.890360132212964*^9, 3.890360180175056*^9}, {3.8903602699972754`*^9, 
-   3.890360286639093*^9}, {3.890360348731464*^9, 3.890360349039323*^9}},
- CellLabel->"In[6]:=",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+   3.890360286639093*^9}, {3.890360348731464*^9, 3.890360349039323*^9}, {
+   3.8903609457772827`*^9, 3.890360945905719*^9}},
+ CellLabel->"In[14]:=",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -2746,7 +2745,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610718559593058137], {
+                    3610719199648137305], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -2979,7 +2978,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610718559593058137], {
+                    3610719199648137305], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -3131,7 +3130,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483\"", 
+                    "\"TCPSERVER-3580cf0d-6eda-4ef2-9429-d208afd87d05\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -3238,7 +3237,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483\"", 
+                    "\"TCPSERVER-3580cf0d-6eda-4ef2-9429-d208afd87d05\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -3265,7 +3264,7 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483"], 
+                   "TCPSERVER-3580cf0d-6eda-4ef2-9429-d208afd87d05"], 
                    Selectable -> False, Editable -> False, SelectWithContents -> 
                    True], "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
@@ -3284,7 +3283,7 @@ Cell[BoxData[
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610718559593058137],
+  SocketListener[3610719199648137305],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
@@ -3292,37 +3291,748 @@ Cell[BoxData[
   3.890359587453292*^9, {3.89035992894007*^9, 3.8903599528178463`*^9}, 
    3.8903599894526243`*^9, 3.8903601325892887`*^9, 3.890360184189907*^9, {
    3.890360272746563*^9, 3.890360288219729*^9}, 3.890360349557804*^9, 
-   3.8903606524758472`*^9},
- CellLabel->"Out[6]=",ExpressionUUID->"818bc1c8-9697-4dae-bc45-00a2905b5df5"]
+   3.8903606524758472`*^9, 3.890360950621985*^9},
+ CellLabel->"Out[14]=",ExpressionUUID->"91c9036a-ea45-4b4e-b0b2-257841146760"]
 }, Open  ]],
 
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  CellChangeTimes->{{3.890359588116479*^9, 3.890359590726398*^9}},
- CellLabel->"In[7]:=",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+ CellLabel->"In[15]:=",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+
+Cell[CellGroupData[{
 
 Cell[BoxData[
- RowBox[{
-  RowBox[{"GenerateHTTPResponse", "[", 
-   RowBox[{
-    RowBox[{"APIFunction", "[", 
-     RowBox[{
-      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+ RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"<|", 
+   RowBox[{"\"\<Endpoints\>\"", "->", 
+    RowBox[{"<|", 
+     RowBox[{"\"\<cityPopulation\>\"", "->", 
+      RowBox[{"APIFunction", "[", 
+       RowBox[{
+        RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+        RowBox[{
+         RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
+     "|>"}]}], "|>"}], "]"}]], "Input",
+ CellChangeTimes->{{3.890360848127894*^9, 3.89036086622954*^9}, {
+  3.890360949309045*^9, 3.890360967315826*^9}},
+ CellLabel->"In[17]:=",ExpressionUUID->"fad4aa06-d37e-4d51-af6f-6bc9ed657ab3"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPlugin",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"ExperimentalPlugin\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"ExperimentalPlugin\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   GridBox[{{
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"cityPopulation\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"cityPopulation\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                    "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "cityPopulation", "Prompt" -> 
+                    Missing["NotSpecified"], 
+                    "Parameters" -> {
+                    "city" -> <|
+                    "Interpreter" -> "City", "Help" -> 
+                    Missing["NotSpecified"], "Required" -> True|>}, 
+                    "Function" -> (Slot["city"]["Population"]& ), 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
+                    Editable -> False, SelectWithContents -> True]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                   "Column"], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
+   "Name" -> "ExperimentalPlugin", "Description" -> "", "Prompt" -> "", 
+    "Endpoints" -> {
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "cityPopulation", "Prompt" -> Missing["NotSpecified"],
+         "Parameters" -> {
+         "city" -> <|
+           "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>}, 
+        "Function" -> (Slot["city"]["Population"]& ), 
+        "APIFunctionOptions" -> {}|>, {}]}|>, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{{3.890360850301125*^9, 3.890360866530312*^9}, 
+   3.890362434910489*^9},
+ CellLabel->"Out[17]=",ExpressionUUID->"cc236e89-aa05-4468-ac3d-7f0fb8f96e9c"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"\"\<prompt\>\"", ",", 
+   RowBox[{"<|", 
+    RowBox[{"\"\<cityPopulation\>\"", "->", 
+     RowBox[{"APIFunction", "[", 
       RowBox[{
-       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}], ",", 
-      RowBox[{"{", 
-       RowBox[{"\"\<WL\>\"", ",", "\"\<HTML\>\""}], "}"}]}], "]"}], ",", 
-    RowBox[{"HTTPRequest", "[", "\"\<localhost?city=Chicago\>\"", "]"}]}], 
-   "]"}], "[", "\"\<Body\>\"", "]"}]], "Input",
- CellChangeTimes->{{3.8903600512918797`*^9, 3.8903600930752087`*^9}, {
-  3.8903601245180407`*^9, 3.890360125491445*^9}, {3.890360332050372*^9, 
-  3.890360339271503*^9}},
- CellLabel->"In[9]:=",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
+       RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+       RowBox[{
+        RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}]}], "]"}]}], 
+    "|>"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.890362252429682*^9, 3.890362254234458*^9}},
+ CellLabel->"In[16]:=",ExpressionUUID->"d5f62a4e-6c0d-4405-846a-92740915f975"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPlugin",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"ExperimentalPlugin\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"ExperimentalPlugin\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   GridBox[{{
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"cityPopulation\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"cityPopulation\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                    "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "cityPopulation", "Prompt" -> 
+                    Missing["NotSpecified"], 
+                    "Parameters" -> {
+                    "city" -> <|
+                    "Interpreter" -> "City", "Help" -> 
+                    Missing["NotSpecified"], "Required" -> True|>}, 
+                    "Function" -> (Slot["city"]["Population"]& ), 
+                    "APIFunctionOptions" -> {}|>, {}], Editable -> False, 
+                    SelectWithContents -> True, Selectable -> False]}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                   "Column"], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"prompt\"", "SummaryItem"]}]}}, AutoDelete -> False,
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
+   "Name" -> "ExperimentalPlugin", "Description" -> "", "Prompt" -> "prompt", 
+    "Endpoints" -> {
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "cityPopulation", "Prompt" -> Missing["NotSpecified"],
+         "Parameters" -> {
+         "city" -> <|
+           "Interpreter" -> "City", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>}, 
+        "Function" -> (Slot["city"]["Population"]& ), 
+        "APIFunctionOptions" -> {}|>, {}]}|>, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.890362254536558*^9},
+ CellLabel->"Out[16]=",ExpressionUUID->"dfc1d72f-117d-406b-a6cb-737849d84036"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"<|", "|>"}], "]"}]], "Input",
+ CellChangeTimes->{3.890397170175687*^9},
+ CellLabel->"In[36]:=",ExpressionUUID->"a87b0317-080a-4aa1-a3c3-a622b3ee6f73"],
+
+Cell[BoxData[
+ TemplateBox[{
+  "KeyValueMap", "invak", 
+   "\"The argument \\!\\(\\*RowBox[{\\\"{\\\", \\\"}\\\"}]\\) is not a valid \
+Association.\"", 2, 36, 22, 19277150584409250387, "Local"},
+  "MessageTemplate"]], "Message", "MSG",
+ CellChangeTimes->{3.8903971706176233`*^9},
+ CellLabel->
+  "During evaluation of \
+In[36]:=",ExpressionUUID->"91d3b086-20de-49c7-98cd-e3dd3d6965d8"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["Failure",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected a single ChatGPTPluginEndpoint, a list with at \
+least one ChatGPTPluginEndpoint, or an association specifying \
+ChatGPTEndpoints, but found \\!\\(\\*TagBox[RowBox[{\\\"KeyValueMap\\\", \
+\\\"[\\\", RowBox[{\\\"ChatGPTPluginEndpoint\\\", \\\",\\\", \
+RowBox[{\\\"{\\\", \\\"}\\\"}]}], \\\"]\\\"}], Function[Short[Slot[1], \
+5]]]\\) instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidEndpointsSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"Endpointspecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"KeyValueMap", "[", 
+                    RowBox[{"ChatGPTPluginEndpoint", ",", 
+                    RowBox[{"{", "}"}]}], "]"}], HoldForm], 
+                  "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected a single ChatGPTPluginEndpoint, a list with at \
+least one ChatGPTPluginEndpoint, or an association specifying \
+ChatGPTEndpoints, but found \\!\\(\\*TagBox[RowBox[{\\\"KeyValueMap\\\", \
+\\\"[\\\", RowBox[{\\\"ChatGPTPluginEndpoint\\\", \\\",\\\", \
+RowBox[{\\\"{\\\", \\\"}\\\"}]}], \\\"]\\\"}], Function[Short[Slot[1], \
+5]]]\\) instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidEndpointsSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"Endpointspecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"KeyValueMap", "[", 
+                    RowBox[{"ChatGPTPluginEndpoint", ",", 
+                    RowBox[{"{", "}"}]}], "]"}], HoldForm], "SummaryItem"]}]}}
+             , 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Failure[
+  "InvalidEndpointsSpecification", <|
+   "MessageTemplate" -> 
+    "Expected a single ChatGPTPluginEndpoint, a list with at least one \
+ChatGPTPluginEndpoint, or an association specifying ChatGPTEndpoints, but \
+found `1` instead.", "MessageParameters" -> {
+      KeyValueMap[Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint, {}]}, 
+    "Endpointspecification" -> 
+    KeyValueMap[Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint, {}]|>],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.890397170636805*^9},
+ CellLabel->"Out[36]=",ExpressionUUID->"02b4147c-f493-4377-a015-c10e0885dcd0"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"<|", 
+   RowBox[{"\"\<Name\>\"", "->", "\"\<test\>\""}], "|>"}], "]"}]], "Input",
+ CellChangeTimes->{{3.8903971818827868`*^9, 3.890397184584745*^9}},
+ CellLabel->"In[37]:=",ExpressionUUID->"710deb99-51ea-4d52-a439-b8774cd074ae"],
+
+Cell[BoxData[
+ TemplateBox[{
+  "KeyValueMap", "invak", 
+   "\"The argument \\!\\(\\*RowBox[{\\\"{\\\", \\\"}\\\"}]\\) is not a valid \
+Association.\"", 2, 37, 23, 19277150584409250387, "Local"},
+  "MessageTemplate"]], "Message", "MSG",
+ CellChangeTimes->{3.890397184830987*^9},
+ CellLabel->
+  "During evaluation of \
+In[37]:=",ExpressionUUID->"a172a2c8-188c-4485-9c9c-ca0a25c7aafb"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["Failure",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected a single ChatGPTPluginEndpoint, a list with at \
+least one ChatGPTPluginEndpoint, or an association specifying \
+ChatGPTEndpoints, but found \\!\\(\\*TagBox[RowBox[{\\\"KeyValueMap\\\", \
+\\\"[\\\", RowBox[{\\\"ChatGPTPluginEndpoint\\\", \\\",\\\", \
+RowBox[{\\\"{\\\", \\\"}\\\"}]}], \\\"]\\\"}], Function[Short[Slot[1], \
+5]]]\\) instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidEndpointsSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"Endpointspecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"KeyValueMap", "[", 
+                    RowBox[{"ChatGPTPluginEndpoint", ",", 
+                    RowBox[{"{", "}"}]}], "]"}], HoldForm], 
+                  "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected a single ChatGPTPluginEndpoint, a list with at \
+least one ChatGPTPluginEndpoint, or an association specifying \
+ChatGPTEndpoints, but found \\!\\(\\*TagBox[RowBox[{\\\"KeyValueMap\\\", \
+\\\"[\\\", RowBox[{\\\"ChatGPTPluginEndpoint\\\", \\\",\\\", \
+RowBox[{\\\"{\\\", \\\"}\\\"}]}], \\\"]\\\"}], Function[Short[Slot[1], \
+5]]]\\) instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidEndpointsSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"Endpointspecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"KeyValueMap", "[", 
+                    RowBox[{"ChatGPTPluginEndpoint", ",", 
+                    RowBox[{"{", "}"}]}], "]"}], HoldForm], "SummaryItem"]}]}}
+             , 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Failure[
+  "InvalidEndpointsSpecification", <|
+   "MessageTemplate" -> 
+    "Expected a single ChatGPTPluginEndpoint, a list with at least one \
+ChatGPTPluginEndpoint, or an association specifying ChatGPTEndpoints, but \
+found `1` instead.", "MessageParameters" -> {
+      KeyValueMap[Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint, {}]}, 
+    "Endpointspecification" -> 
+    KeyValueMap[Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint, {}]|>],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.890397184846509*^9},
+ CellLabel->"Out[37]=",ExpressionUUID->"346de3d9-00c1-412f-aed1-a8e46cca4625"]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]]
 },
-WindowSize->{808, 897},
-WindowMargins->{{Automatic, 78}, {31, Automatic}},
+WindowSize->{844, 897},
+WindowMargins->{{Automatic, 96}, {31, Automatic}},
 FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
 StyleDefinitions->"Default.nb",
 ExpressionUUID->"70ebc363-7b9f-4bf8-a98e-37b9b05400eb"
@@ -3400,11 +4110,28 @@ Cell[78477, 1729, 39321, 762, 61, "Output",ExpressionUUID->"0b71c202-e5ea-4d50-9
 Cell[117813, 2494, 211, 3, 30, "Input",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
 Cell[118027, 2499, 278, 6, 30, "Input",ExpressionUUID->"2fe2361c-9ce4-45c0-8268-d6b79954fa52"],
 Cell[CellGroupData[{
-Cell[118330, 2509, 913, 19, 94, "Input",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
-Cell[119246, 2530, 39496, 765, 61, "Output",ExpressionUUID->"818bc1c8-9697-4dae-bc45-00a2905b5df5"]
+Cell[118330, 2509, 875, 18, 73, "Input",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+Cell[119208, 2529, 39519, 765, 61, "Output",ExpressionUUID->"91c9036a-ea45-4b4e-b0b2-257841146760"]
 }, Open  ]],
-Cell[158757, 3298, 214, 3, 30, "Input",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
-Cell[158974, 3303, 734, 16, 52, "Input",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
+Cell[158742, 3297, 215, 3, 30, "Input",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+Cell[CellGroupData[{
+Cell[158982, 3304, 608, 14, 52, "Input",ExpressionUUID->"fad4aa06-d37e-4d51-af6f-6bc9ed657ab3"],
+Cell[159593, 3320, 9906, 196, 61, "Output",ExpressionUUID->"cc236e89-aa05-4468-ac3d-7f0fb8f96e9c"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[169536, 3521, 522, 12, 52, "Input",ExpressionUUID->"d5f62a4e-6c0d-4405-846a-92740915f975"],
+Cell[170061, 3535, 9987, 198, 61, "Output",ExpressionUUID->"dfc1d72f-117d-406b-a6cb-737849d84036"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[180085, 3738, 207, 4, 30, "Input",ExpressionUUID->"a87b0317-080a-4aa1-a3c3-a622b3ee6f73"],
+Cell[180295, 3744, 384, 9, 28, "Message",ExpressionUUID->"91d3b086-20de-49c7-98cd-e3dd3d6965d8"],
+Cell[180682, 3755, 5940, 125, 95, "Output",ExpressionUUID->"02b4147c-f493-4377-a015-c10e0885dcd0"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[186659, 3885, 285, 5, 30, "Input",ExpressionUUID->"710deb99-51ea-4d52-a439-b8774cd074ae"],
+Cell[186947, 3892, 382, 9, 28, "Message",ExpressionUUID->"a172a2c8-188c-4485-9c9c-ca0a25c7aafb"],
+Cell[187332, 3903, 5940, 125, 95, "Output",ExpressionUUID->"346de3d9-00c1-412f-aed1-a8e46cca4625"]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]]
 }

--- a/Notes/chatGPTPluginsAssociations.nb
+++ b/Notes/chatGPTPluginsAssociations.nb
@@ -3,10 +3,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[         0,          0]
-NotebookDataLength[    164482,       3413]
-NotebookOptionsPosition[    159889,       3324]
-NotebookOutlinePosition[    160286,       3340]
-CellTagsIndexPosition[    160243,       3337]
+NotebookDataLength[    164329,       3412]
+NotebookOptionsPosition[    159736,       3323]
+NotebookOutlinePosition[    160133,       3339]
+CellTagsIndexPosition[    160090,       3336]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -262,7 +262,7 @@ Cell["Experiments", "Section",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.890331632025361*^9, 3.8903316323306837`*^9}},
- CellLabel->"In[22]:=",ExpressionUUID->"50faaac4-34f8-4f17-b62f-8ed6dae7e0bb"],
+ CellLabel->"In[13]:=",ExpressionUUID->"50faaac4-34f8-4f17-b62f-8ed6dae7e0bb"],
 
 Cell[CellGroupData[{
 
@@ -310,8 +310,9 @@ Cell[BoxData[
    3.890357431994145*^9, 3.890357817044326*^9, 3.890358575822405*^9, 
    3.890358639400938*^9, 3.89035868850769*^9, 3.890358817458146*^9, 
    3.890358884355093*^9, 3.8903589980125637`*^9, 3.890359392401732*^9, 
-   3.890359473233597*^9, 3.890359924058857*^9, 3.890360260098257*^9},
- CellLabel->"Out[1]=",ExpressionUUID->"d0da8156-35ac-4c2a-a64a-677141bb5bf2"]
+   3.890359473233597*^9, 3.890359924058857*^9, 3.890360260098257*^9, 
+   3.8903606415828533`*^9},
+ CellLabel->"Out[1]=",ExpressionUUID->"04d373d8-f602-49a4-96d3-cbc44ea8af0a"]
 }, Open  ]],
 
 Cell["Load it:", "Text",
@@ -1234,7 +1235,7 @@ contents of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t",
  CellChangeTimes->{{3.890229392377411*^9, 3.890229585140503*^9}, {
   3.890358583283368*^9, 3.89035859403614*^9}, {3.890358696783222*^9, 
   3.890358712428619*^9}, {3.8903594034094*^9, 3.890359403538176*^9}},
- CellLabel->"In[4]:=",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
+ CellLabel->"In[3]:=",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -1390,7 +1391,6 @@ Cell[BoxData[
                     "Function" -> (StringRiffle[
                     Map[FileNameTake, 
                     FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
-                    "OutputFormat" -> Automatic, 
                     "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
                     Editable -> False, SelectWithContents -> True]}, {
                     InterpretationBox[
@@ -1481,7 +1481,6 @@ contents of files that you are sure exist.",
                     "Function" -> (StringRiffle[
                     Map[FileNameTake, 
                     FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
-                    "OutputFormat" -> Automatic, 
                     "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
                     Editable -> False, SelectWithContents -> True]}, {
                     InterpretationBox[
@@ -1575,9 +1574,9 @@ contents of files that you are sure exist.",
                     FileNameJoin[{$CellContext`exampleDirectory, 
                     Slot["oldName"]}], 
                     FileNameJoin[{$CellContext`exampleDirectory, 
-                    Slot["newName"]}]]& ), "OutputFormat" -> Automatic, 
-                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
-                    Editable -> False, SelectWithContents -> True]}}, 
+                    Slot["newName"]}]]& ), "APIFunctionOptions" -> {}|>, {}], 
+                    Selectable -> False, Editable -> False, 
+                    SelectWithContents -> True]}}, 
                     GridBoxAlignment -> {"Columns" -> {{Left}}}, 
                     DefaultBaseStyle -> "Column", 
                     GridBoxItemSize -> {
@@ -1608,44 +1607,43 @@ contents of files that you are sure exist.",
   Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
    "Name" -> "FileOrganizer", "Description" -> 
     "View and organize files on a computer.", "Prompt" -> 
-    "View and organize files on a computer."|>, {
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
-     "OperationID" -> "getFileNames", "Prompt" -> 
-      "lists the names of the files", "Parameters" -> {}, 
-      "Function" -> (StringRiffle[
-        Map[FileNameTake, 
-         FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
-      "OutputFormat" -> Automatic, "APIFunctionOptions" -> {}|>, {}], 
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
-     "OperationID" -> "getFileContents", "Prompt" -> 
-      "gets the contents of a file as text. Only request the contents of \
+    "View and organize files on a computer.", "Endpoints" -> {
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "getFileNames", "Prompt" -> 
+        "lists the names of the files", "Parameters" -> {}, 
+        "Function" -> (StringRiffle[
+          Map[FileNameTake, 
+           FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+        "APIFunctionOptions" -> {}|>, {}], 
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "getFileContents", "Prompt" -> 
+        "gets the contents of a file as text. Only request the contents of \
 files that you are sure exist.", 
-      "Parameters" -> {
-       "name" -> <|
-         "Interpreter" -> "String", "Help" -> "the name of the file", 
-          "Required" -> True|>}, "Function" -> (StringRiffle[
-        Map[FileNameTake, 
-         FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
-      "OutputFormat" -> Automatic, "APIFunctionOptions" -> {}|>, {}], 
-    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
-     "OperationID" -> "renameFile", "Prompt" -> Missing["NotSpecified"], 
-      "Parameters" -> {
-       "oldName" -> <|
-         "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
-          "Required" -> True|>, 
-        "newName" -> <|
-         "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
-          "Required" -> True|>}, "Function" -> (RenameFile[
-        FileNameJoin[{$CellContext`exampleDirectory, 
-          Slot["oldName"]}], 
-        FileNameJoin[{$CellContext`exampleDirectory, 
-          Slot["newName"]}]]& ), "OutputFormat" -> Automatic, 
-      "APIFunctionOptions" -> {}|>, {}]}, {}],
+        "Parameters" -> {
+         "name" -> <|
+           "Interpreter" -> "String", "Help" -> "the name of the file", 
+            "Required" -> True|>}, "Function" -> (StringRiffle[
+          Map[FileNameTake, 
+           FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+        "APIFunctionOptions" -> {}|>, {}], 
+      Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+       "OperationID" -> "renameFile", "Prompt" -> Missing["NotSpecified"], 
+        "Parameters" -> {
+         "oldName" -> <|
+           "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>, 
+          "newName" -> <|
+           "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
+            "Required" -> True|>}, "Function" -> (RenameFile[
+          FileNameJoin[{$CellContext`exampleDirectory, 
+            Slot["oldName"]}], 
+          FileNameJoin[{$CellContext`exampleDirectory, 
+            Slot["newName"]}]]& ), "APIFunctionOptions" -> {}|>, {}]}|>, {}],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
- CellChangeTimes->{3.890359403860073*^9},
- CellLabel->"Out[4]=",ExpressionUUID->"bc63e54e-6297-4b23-a979-5a2e83d746b1"]
+ CellChangeTimes->{3.890359403860073*^9, 3.890360646363315*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"f554b1d6-dc5d-45a1-bc47-03657c81ae4e"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -1727,7 +1725,7 @@ contents of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t",
  CellChangeTimes->{{3.890229392377411*^9, 3.890229585140503*^9}, {
   3.890358583283368*^9, 3.89035859403614*^9}, {3.890358696783222*^9, 
   3.890358712428619*^9}, {3.8903594034094*^9, 3.8903594107683487`*^9}},
- CellLabel->"In[3]:=",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
+ CellLabel->"In[4]:=",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -1741,11 +1739,10 @@ Cell[BoxData[
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
-               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
-              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -1923,12 +1920,14 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, AspectRatio -> Automatic, 
-             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
-               Dynamic[
-               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
-             PlotRangePadding -> Automatic], 
+               1.}}]}, {ImageSize -> {Automatic, 
+                Dynamic[
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])]}, AspectRatio -> Automatic, 
+              ImagePadding -> {{0., 0.}, {0., 0.}}, 
+              ImageSize -> {64.43359375, 68.}, 
+              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
+              Automatic}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -1946,7 +1945,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610716040175539680], {
+                    3610718550766472306], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -1954,32 +1953,29 @@ Cell[BoxData[
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
                     Blank[]] :> Missing["NotAvailable"]}], 
                     Missing["NotAvailable"]], StandardForm], 
-                   ImageSizeCache -> {109., {2., 8.150390625}}, 
                    TrackedSymbols :> {
                     ZeroMQLink`PackageScope`$SocketListeners}], 
-                  "SummaryItem"]}]}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+                  "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
-        GridBox[{{
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
-               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
-              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -2157,12 +2153,14 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, AspectRatio -> Automatic, 
-             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
-               Dynamic[
-               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
-             PlotRangePadding -> Automatic], 
+               1.}}]}, {ImageSize -> {Automatic, 
+                Dynamic[
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])]}, AspectRatio -> Automatic, 
+              ImagePadding -> {{0., 0.}, {0., 0.}}, 
+              ImageSize -> {64.43359375, 68.}, 
+              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
+              Automatic}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -2180,7 +2178,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610716040175539680], {
+                    3610718550766472306], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -2188,7 +2186,6 @@ Cell[BoxData[
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
                     Blank[]] :> Missing["NotAvailable"]}], 
                     Missing["NotAvailable"]], StandardForm], 
-                   ImageSizeCache -> {109., {2., 8.150390625}}, 
                    TrackedSymbols :> {
                     ZeroMQLink`PackageScope`$SocketListeners}], 
                   "SummaryItem"]}]}, {
@@ -2333,7 +2330,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44\"", 
+                    "\"TCPSERVER-329a4b5b-1625-47fd-85b3-b3e9b4151433\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -2440,7 +2437,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44\"", 
+                    "\"TCPSERVER-329a4b5b-1625-47fd-85b3-b3e9b4151433\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -2467,37 +2464,38 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44"], 
-                   Editable -> False, SelectWithContents -> True, Selectable -> 
-                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+                   "TCPSERVER-329a4b5b-1625-47fd-85b3-b3e9b4151433"], 
+                   Selectable -> False, Editable -> False, SelectWithContents -> 
+                   True], "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610716040175539680],
+  SocketListener[3610718550766472306],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
- CellChangeTimes->{3.8903594118373632`*^9, 3.890359479216567*^9},
- CellLabel->"Out[3]=",ExpressionUUID->"a63136f8-7c3f-4fcf-a5d7-3d01c1ef6104"]
+ CellChangeTimes->{3.8903594118373632`*^9, 3.890359479216567*^9, 
+  3.890360648750968*^9},
+ CellLabel->"Out[4]=",ExpressionUUID->"0b71c202-e5ea-4d50-9d39-ef62587e853e"]
 }, Open  ]],
 
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "%", "]"}]], "Input",
  CellChangeTimes->{{3.8903594799535027`*^9, 3.890359486794615*^9}},
- CellLabel->"In[4]:=",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
+ CellLabel->"In[5]:=",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
 
 Cell[BoxData[
  RowBox[{"HandlerFunctions", "->", 
@@ -2528,7 +2526,7 @@ Cell[BoxData[
    3.89035994845609*^9, 3.890359949969782*^9}, 3.890359987081604*^9, {
    3.890360132212964*^9, 3.890360180175056*^9}, {3.8903602699972754`*^9, 
    3.890360286639093*^9}, {3.890360348731464*^9, 3.890360349039323*^9}},
- CellLabel->"In[11]:=",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+ CellLabel->"In[6]:=",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -2542,11 +2540,10 @@ Cell[BoxData[
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
-               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
-              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -2724,12 +2721,14 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, AspectRatio -> Automatic, 
-             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
-               Dynamic[
-               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
-             PlotRangePadding -> Automatic], 
+               1.}}]}, {ImageSize -> {Automatic, 
+                Dynamic[
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])]}, AspectRatio -> Automatic, 
+              ImagePadding -> {{0., 0.}, {0., 0.}}, 
+              ImageSize -> {64.43359375, 68.}, 
+              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
+              Automatic}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -2747,7 +2746,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610717907711726446], {
+                    3610718559593058137], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -2755,32 +2754,29 @@ Cell[BoxData[
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
                     Blank[]] :> Missing["NotAvailable"]}], 
                     Missing["NotAvailable"]], StandardForm], 
-                   ImageSizeCache -> {7., {0., 8.}}, 
                    TrackedSymbols :> {
                     ZeroMQLink`PackageScope`$SocketListeners}], 
-                  "SummaryItem"]}]}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+                  "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
-        GridBox[{{
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
             PaneBox[
              ButtonBox[
               DynamicBox[
                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              Appearance -> None, BaseStyle -> {}, 
-              ButtonFunction :> (Typeset`open$$ = False), Evaluator -> 
-              Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
@@ -2958,12 +2954,14 @@ Cell[BoxData[
                 PlotRange -> {{20, 80}, {0, 70}}], 
                Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
                15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
-               1.}}]}, AspectRatio -> Automatic, 
-             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
-               Dynamic[
-               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
-             PlotRangePadding -> Automatic], 
+               1.}}]}, {ImageSize -> {Automatic, 
+                Dynamic[
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])]}, AspectRatio -> Automatic, 
+              ImagePadding -> {{0., 0.}, {0., 0.}}, 
+              ImageSize -> {64.43359375, 68.}, 
+              PlotRange -> {{0., 24.}, {0., 24.}}, PlotRangePadding -> 
+              Automatic}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
@@ -2981,7 +2979,7 @@ Cell[BoxData[
                     Replace[
                     ZeroMQLink`PackageScope`safeSocketProperty[
                     ZeroMQLink`PackageScope`$SocketListeners, 
-                    3610717907711726446], {
+                    3610718559593058137], {
                     Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
                     Blank[Association]] :> 
                     ZeroMQLink`PackageScope`listenerMessageCount[
@@ -3133,7 +3131,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5\"", 
+                    "\"TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
                     GridBoxAlignment -> {
                     "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
@@ -3240,7 +3238,7 @@ Cell[BoxData[
                     TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
                     "\[InvisibleSpace]", 
                     TagBox[
-                    "\"TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5\"", 
+                    "\"TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483\"", 
                     "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
                     
                     RowBox[{
@@ -3267,40 +3265,41 @@ Cell[BoxData[
                     Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
                     "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
                    SocketObject[
-                   "TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5"], 
-                   Editable -> False, SelectWithContents -> True, Selectable -> 
-                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+                   "TCPSERVER-a9a9264e-91e4-46ed-a06a-c19188bea483"], 
+                   Selectable -> False, Editable -> False, SelectWithContents -> 
+                   True], "SummaryItem"]}]}}, 
              GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
-  SocketListener[3610717907711726446],
+  SocketListener[3610718559593058137],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
  CellChangeTimes->{
   3.890359587453292*^9, {3.89035992894007*^9, 3.8903599528178463`*^9}, 
    3.8903599894526243`*^9, 3.8903601325892887`*^9, 3.890360184189907*^9, {
-   3.890360272746563*^9, 3.890360288219729*^9}, 3.890360349557804*^9},
- CellLabel->"Out[11]=",ExpressionUUID->"8f82033c-ded6-4e0d-9c60-b60d7430782e"]
+   3.890360272746563*^9, 3.890360288219729*^9}, 3.890360349557804*^9, 
+   3.8903606524758472`*^9},
+ CellLabel->"Out[6]=",ExpressionUUID->"818bc1c8-9697-4dae-bc45-00a2905b5df5"]
 }, Open  ]],
 
 Cell[BoxData[
  RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
  CellChangeTimes->{{3.890359588116479*^9, 3.890359590726398*^9}},
- CellLabel->"In[12]:=",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+ CellLabel->"In[7]:=",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
 
 Cell[BoxData[
  RowBox[{
@@ -3351,61 +3350,61 @@ Cell[11048, 268, 154, 3, 54, "Subsection",ExpressionUUID->"3b962326-075c-49e4-a1
 Cell[11205, 273, 526, 15, 35, "Text",ExpressionUUID->"956860d2-cea8-4fd5-93c8-40736859d48a"],
 Cell[CellGroupData[{
 Cell[11756, 292, 350, 6, 30, "Input",ExpressionUUID->"c546cbcc-31d1-47c4-b3af-38bd39a8f3cc"],
-Cell[12109, 300, 830, 13, 34, "Output",ExpressionUUID->"d0da8156-35ac-4c2a-a64a-677141bb5bf2"]
+Cell[12109, 300, 858, 14, 34, "Output",ExpressionUUID->"04d373d8-f602-49a4-96d3-cbc44ea8af0a"]
 }, Open  ]],
-Cell[12954, 316, 151, 3, 35, "Text",ExpressionUUID->"87a8fe9d-3490-4edb-b7de-f9a7f692d0e1"],
-Cell[13108, 321, 285, 4, 30, "Input",ExpressionUUID->"836553a1-1e26-4ebe-b9e5-26468272d409"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[13430, 330, 161, 3, 54, "Subsection",ExpressionUUID->"9b30a094-3f54-42da-8ed7-ddb4e6e2de05"],
-Cell[CellGroupData[{
-Cell[13616, 337, 709, 16, 115, "Input",ExpressionUUID->"e602e4ef-30e7-4c4e-867c-be878ec0d31c"],
-Cell[14328, 355, 4162, 88, 61, "Output",ExpressionUUID->"15818a04-fb94-41d1-9647-2940b3bfa6fd"]
+Cell[12982, 317, 151, 3, 35, "Text",ExpressionUUID->"87a8fe9d-3490-4edb-b7de-f9a7f692d0e1"],
+Cell[13136, 322, 285, 4, 30, "Input",ExpressionUUID->"836553a1-1e26-4ebe-b9e5-26468272d409"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18527, 448, 719, 17, 115, "Input",ExpressionUUID->"12197b44-e995-487d-b88b-ff9bc26baf27"],
-Cell[19249, 467, 1702, 35, 129, "Output",ExpressionUUID->"f8cb8051-9a26-4243-b58e-2eec72f33ca1"]
+Cell[13458, 331, 161, 3, 54, "Subsection",ExpressionUUID->"9b30a094-3f54-42da-8ed7-ddb4e6e2de05"],
+Cell[CellGroupData[{
+Cell[13644, 338, 709, 16, 115, "Input",ExpressionUUID->"e602e4ef-30e7-4c4e-867c-be878ec0d31c"],
+Cell[14356, 356, 4162, 88, 61, "Output",ExpressionUUID->"15818a04-fb94-41d1-9647-2940b3bfa6fd"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[20988, 507, 601, 14, 115, "Input",ExpressionUUID->"af95f926-369a-4089-9f03-8626ac5ae92b"],
-Cell[21592, 523, 5672, 121, 95, "Output",ExpressionUUID->"67911a58-48ba-4be0-92c5-840427935cea"]
+Cell[18555, 449, 719, 17, 115, "Input",ExpressionUUID->"12197b44-e995-487d-b88b-ff9bc26baf27"],
+Cell[19277, 468, 1702, 35, 129, "Output",ExpressionUUID->"f8cb8051-9a26-4243-b58e-2eec72f33ca1"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[27301, 649, 911, 19, 178, "Input",ExpressionUUID->"32e00657-2772-4701-9e58-3ed83681adf6"],
-Cell[28215, 670, 4345, 94, 61, "Output",ExpressionUUID->"fe19a72f-4153-4bd2-aa90-ecdd0858e718"]
+Cell[21016, 508, 601, 14, 115, "Input",ExpressionUUID->"af95f926-369a-4089-9f03-8626ac5ae92b"],
+Cell[21620, 524, 5672, 121, 95, "Output",ExpressionUUID->"67911a58-48ba-4be0-92c5-840427935cea"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[32597, 769, 763, 15, 157, "Input",ExpressionUUID->"6d4ce8b7-be90-44fe-9ab6-6214cf415be7"],
-Cell[33363, 786, 4172, 88, 61, "Output",ExpressionUUID->"d2dd5fdb-0a6d-4e71-8630-7222cc0c93a2"]
+Cell[27329, 650, 911, 19, 178, "Input",ExpressionUUID->"32e00657-2772-4701-9e58-3ed83681adf6"],
+Cell[28243, 671, 4345, 94, 61, "Output",ExpressionUUID->"fe19a72f-4153-4bd2-aa90-ecdd0858e718"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[37572, 879, 286, 5, 30, "Input",ExpressionUUID->"f76cb45d-7fea-40a2-a53c-9c6d12fd306e"],
-Cell[37861, 886, 5976, 119, 81, "Output",ExpressionUUID->"44937732-1b2c-4c84-9536-203983b7411c"]
+Cell[32625, 770, 763, 15, 157, "Input",ExpressionUUID->"6d4ce8b7-be90-44fe-9ab6-6214cf415be7"],
+Cell[33391, 787, 4172, 88, 61, "Output",ExpressionUUID->"d2dd5fdb-0a6d-4e71-8630-7222cc0c93a2"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[43874, 1010, 4413, 92, 57, "Input",ExpressionUUID->"15f5ae47-1c8d-408d-b893-59c601c2ad19"],
-Cell[48290, 1104, 224, 3, 34, "Output",ExpressionUUID->"64b69496-cc70-4093-bb8c-973e77e54fe6"]
+Cell[37600, 880, 286, 5, 30, "Input",ExpressionUUID->"f76cb45d-7fea-40a2-a53c-9c6d12fd306e"],
+Cell[37889, 887, 5976, 119, 81, "Output",ExpressionUUID->"44937732-1b2c-4c84-9536-203983b7411c"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48551, 1112, 664, 15, 73, "Input",ExpressionUUID->"390cdd94-d84d-42d0-96d3-0d53bce558e4"],
-Cell[49218, 1129, 1031, 25, 60, "Output",ExpressionUUID->"5c434661-715e-4417-954e-24386bb412c7"]
+Cell[43902, 1011, 4413, 92, 57, "Input",ExpressionUUID->"15f5ae47-1c8d-408d-b893-59c601c2ad19"],
+Cell[48318, 1105, 224, 3, 34, "Output",ExpressionUUID->"64b69496-cc70-4093-bb8c-973e77e54fe6"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[50286, 1159, 3395, 77, 338, "Code",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
-Cell[53684, 1238, 21448, 409, 61, "Output",ExpressionUUID->"bc63e54e-6297-4b23-a979-5a2e83d746b1"]
+Cell[48579, 1113, 664, 15, 73, "Input",ExpressionUUID->"390cdd94-d84d-42d0-96d3-0d53bce558e4"],
+Cell[49246, 1130, 1031, 25, 60, "Output",ExpressionUUID->"5c434661-715e-4417-954e-24386bb412c7"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[75169, 1652, 3403, 77, 338, "Code",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
-Cell[78575, 1731, 39405, 762, 61, "Output",ExpressionUUID->"a63136f8-7c3f-4fcf-a5d7-3d01c1ef6104"]
+Cell[50314, 1160, 3395, 77, 338, "Code",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
+Cell[53712, 1239, 21322, 406, 61, "Output",ExpressionUUID->"f554b1d6-dc5d-45a1-bc47-03657c81ae4e"]
 }, Open  ]],
-Cell[117995, 2496, 211, 3, 30, "Input",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
-Cell[118209, 2501, 278, 6, 30, "Input",ExpressionUUID->"2fe2361c-9ce4-45c0-8268-d6b79954fa52"],
 Cell[CellGroupData[{
-Cell[118512, 2511, 914, 19, 94, "Input",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
-Cell[119429, 2532, 39465, 764, 61, "Output",ExpressionUUID->"8f82033c-ded6-4e0d-9c60-b60d7430782e"]
+Cell[75071, 1650, 3403, 77, 338, "Code",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
+Cell[78477, 1729, 39321, 762, 61, "Output",ExpressionUUID->"0b71c202-e5ea-4d50-9d39-ef62587e853e"]
 }, Open  ]],
-Cell[158909, 3299, 215, 3, 30, "Input",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
-Cell[159127, 3304, 734, 16, 52, "Input",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
+Cell[117813, 2494, 211, 3, 30, "Input",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
+Cell[118027, 2499, 278, 6, 30, "Input",ExpressionUUID->"2fe2361c-9ce4-45c0-8268-d6b79954fa52"],
+Cell[CellGroupData[{
+Cell[118330, 2509, 913, 19, 94, "Input",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+Cell[119246, 2530, 39496, 765, 61, "Output",ExpressionUUID->"818bc1c8-9697-4dae-bc45-00a2905b5df5"]
+}, Open  ]],
+Cell[158757, 3298, 214, 3, 30, "Input",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+Cell[158974, 3303, 734, 16, 52, "Input",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
 }, Open  ]]
 }, Open  ]]
 }

--- a/Notes/chatGPTPluginsAssociations.nb
+++ b/Notes/chatGPTPluginsAssociations.nb
@@ -1,19 +1,12 @@
-(* Content-type: application/vnd.wolfram.mathematica *)
-
-(*** Wolfram Notebook File ***)
-(* http://www.wolfram.com/nb *)
-
-(* CreatedBy='Mathematica 13.2' *)
-
 (*CacheID: 234*)
 (* Internal cache information:
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
-NotebookDataPosition[       158,          7]
-NotebookDataLength[     11330,        278]
-NotebookOptionsPosition[     10770,        261]
-NotebookOutlinePosition[     11168,        277]
-CellTagsIndexPosition[     11125,        274]
+NotebookDataPosition[         0,          0]
+NotebookDataLength[    164482,       3413]
+NotebookOptionsPosition[    159889,       3324]
+NotebookOutlinePosition[    160286,       3340]
+CellTagsIndexPosition[    160243,       3337]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -141,7 +134,7 @@ Cell[BoxData[
          "\"\<Prompt\>\"", " ", "->", " ", 
           "\"\<gets the contents of a file as text. Only request the contents \
 of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t", 
-         RowBox[{"\"\<Arguments\>\"", " ", "->", " ", 
+         RowBox[{"\"\<Parameters\>\"", " ", "->", " ", 
           RowBox[{"{", 
            RowBox[{"\"\<name\>\"", " ", "->", " ", 
             RowBox[{"<|", 
@@ -160,7 +153,7 @@ of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t",
       RowBox[{"\"\<renameFile\>\"", " ", "->", " ", 
        RowBox[{"<|", "\n", "\t\t\t", 
         RowBox[{
-         RowBox[{"\"\<Arguments\>\"", " ", "->", " ", 
+         RowBox[{"\"\<Parameters\>\"", " ", "->", " ", 
           RowBox[{"{", 
            RowBox[{"\"\<oldName\>\"", ",", " ", "\"\<newName\>\""}], "}"}]}], 
          ",", "\n", "\t\t\t", 
@@ -178,8 +171,9 @@ of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t",
                 RowBox[{"exampleDirectory", ",", "#newName"}], "}"}], "]"}]}],
               "]"}], "&"}], ")"}]}]}], "\n", "\t\t", "|>"}]}]}], "\n", "\t", 
      "|>"}]}]}], "\n", "|>"}]], "Code",
- CellChangeTimes->{{3.890229392377411*^9, 
-  3.8902295214632463`*^9}},ExpressionUUID->"142dfd41-0736-4106-9b10-\
+ CellChangeTimes->{{3.890229392377411*^9, 3.8902295214632463`*^9}, {
+  3.8903580984552813`*^9, 
+  3.890358102571003*^9}},ExpressionUUID->"142dfd41-0736-4106-9b10-\
 46ee44e6515c"],
 
 Cell[BoxData[
@@ -257,13 +251,3082 @@ of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t",
   "|>"}]], "Code",
  CellChangeTimes->{{3.890229392377411*^9, 
   3.890229585140503*^9}},ExpressionUUID->"342dd09a-a238-44cd-be98-\
-a2d52da02ac3"]
+a2d52da02ac3"],
+
+Cell[CellGroupData[{
+
+Cell["Experiments", "Section",
+ CellChangeTimes->{{3.8903316180676003`*^9, 
+  3.89033162060643*^9}},ExpressionUUID->"d4b686a7-940b-4bf0-9466-\
+981f2f19d172"],
+
+Cell[BoxData["Quit"], "Input",
+ CellChangeTimes->{{3.890331632025361*^9, 3.8903316323306837`*^9}},
+ CellLabel->"In[22]:=",ExpressionUUID->"50faaac4-34f8-4f17-b62f-8ed6dae7e0bb"],
+
+Cell[CellGroupData[{
+
+Cell["Init", "Subsection",
+ CellChangeTimes->{{3.889485226890408*^9, 
+  3.8894852273176317`*^9}},ExpressionUUID->"3b962326-075c-49e4-a1bb-\
+019d37658131"],
+
+Cell[TextData[{
+ "Install the ",
+ ButtonBox["ChatGPTPluginKit",
+  BaseStyle->"Hyperlink",
+  ButtonData->{
+    URL["https://resources.wolframcloud.com/PacletRepository/resources/\
+Wolfram/ChatGPTPluginKit/"], None},
+  ButtonNote->
+   "https://resources.wolframcloud.com/PacletRepository/resources/Wolfram/\
+ChatGPTPluginKit/"],
+ " paclet:"
+}], "Text",
+ CellChangeTimes->{{3.890139801417428*^9, 3.89013982597797*^9}, {
+  3.890325352935987*^9, 
+  3.8903253616368313`*^9}},ExpressionUUID->"956860d2-cea8-4fd5-93c8-\
+40736859d48a"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"PacletDirectoryLoad", "[", "\"\<~/git/ChatGPTPluginKit\>\"", 
+  "]"}]], "Input",
+ CellChangeTimes->{{3.8894766824414463`*^9, 3.889476714076478*^9}, {
+  3.890325339272937*^9, 3.8903253418855333`*^9}, {3.890332772113976*^9, 
+  3.890332777809052*^9}},
+ CellLabel->"In[1]:=",ExpressionUUID->"c546cbcc-31d1-47c4-b3af-38bd39a8f3cc"],
+
+Cell[BoxData[
+ RowBox[{"{", "\<\"/Users/christopher/git/ChatGPTPluginKit\"\>", 
+  "}"}]], "Output",
+ CellChangeTimes->{
+  3.889476719495153*^9, 3.889548583906661*^9, 3.889621562552203*^9, 
+   3.889707699464698*^9, {3.8897425599552193`*^9, 3.8897425869988317`*^9}, 
+   3.889746364360702*^9, 3.890139838849264*^9, 3.890150641177929*^9, 
+   3.8901519467777*^9, 3.890325345032857*^9, 3.890331646095776*^9, 
+   3.89033277981896*^9, 3.890332832304607*^9, 3.890357255546357*^9, 
+   3.890357431994145*^9, 3.890357817044326*^9, 3.890358575822405*^9, 
+   3.890358639400938*^9, 3.89035868850769*^9, 3.890358817458146*^9, 
+   3.890358884355093*^9, 3.8903589980125637`*^9, 3.890359392401732*^9, 
+   3.890359473233597*^9, 3.890359924058857*^9, 3.890360260098257*^9},
+ CellLabel->"Out[1]=",ExpressionUUID->"d0da8156-35ac-4c2a-a64a-677141bb5bf2"]
+}, Open  ]],
+
+Cell["Load it:", "Text",
+ CellChangeTimes->{{3.8901398323231916`*^9, 
+  3.89013983332917*^9}},ExpressionUUID->"87a8fe9d-3490-4edb-b7de-\
+f9a7f692d0e1"],
+
+Cell[BoxData[
+ RowBox[{"Needs", "[", "\"\<Wolfram`ChatGPTPluginKit`\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.889476716502961*^9, 3.8894767264530697`*^9}, {
+  3.890325395761758*^9, 3.890325398059091*^9}},
+ CellLabel->"In[2]:=",ExpressionUUID->"836553a1-1e26-4ebe-b9e5-26468272d409"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Scratch space", "Subsection",
+ CellChangeTimes->{{3.890331626443565*^9, 
+  3.890331628850319*^9}},ExpressionUUID->"9b30a094-3f54-42da-8ed7-\
+ddb4e6e2de05"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginEndpoint", "[", "\n", "\t\t\t", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{
+    "\"\<getDirectoryFiles\>\"", ",", " ", 
+     "\"\<lists the files in a directory\>\""}], "}"}], ",", "\n", "\t\t\t", 
+   RowBox[{"\"\<path\>\"", " ", "->", " ", 
+    RowBox[{"<|", 
+     RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}], 
+     "|>"}]}], ",", "\n", "\t\t\t", 
+   RowBox[{
+    RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "\n", "\t\t", 
+  "]"}]], "Input",
+ CellChangeTimes->{{3.890357182464031*^9, 3.8903571841682568`*^9}, {
+  3.890357260436544*^9, 3.8903572607797527`*^9}},
+ CellLabel->"In[4]:=",ExpressionUUID->"e602e4ef-30e7-4c4e-867c-be878ec0d31c"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPluginEndpoint",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"lists the files in a directory\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+   "OperationID" -> "getDirectoryFiles", "Prompt" -> 
+    "lists the files in a directory", 
+    "Parameters" -> {
+     "path" -> <|
+       "Interpreter" -> "String", "Help" -> "the path to the directory", 
+        "Required" -> True|>}, "Function" -> (StringReverse[
+      Slot["path"]]& )|>, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{{3.890357179361041*^9, 3.890357184405519*^9}, {
+  3.890357259661373*^9, 3.890357261122241*^9}},
+ CellLabel->"Out[4]=",ExpressionUUID->"15818a04-fb94-41d1-9647-2940b3bfa6fd"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"ChatGPTPluginEndpoint", "[", "\n", "\t\t\t", 
+   RowBox[{
+    RowBox[{"{", 
+     RowBox[{
+     "\"\<getDirectoryFiles\>\"", ",", " ", 
+      "\"\<lists the files in a directory\>\""}], "}"}], ",", "\n", "\t\t\t", 
+    
+    RowBox[{"\"\<path\>\"", " ", "->", " ", 
+     RowBox[{"<|", 
+      RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}], 
+      "|>"}]}], ",", "\n", "\t\t\t", 
+    RowBox[{
+     RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "\n", "\t\t", 
+   "]"}], "[", "\"\<OpenAPIJSON\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.890331656197206*^9, 3.890331715778419*^9}},
+ CellLabel->"In[5]:=",ExpressionUUID->"12197b44-e995-487d-b88b-ff9bc26baf27"],
+
+Cell[BoxData[
+ RowBox[{"\[LeftAssociation]", 
+  RowBox[{"\<\"/getDirectoryFiles\"\>", "\[Rule]", 
+   RowBox[{"\[LeftAssociation]", 
+    RowBox[{"\<\"get\"\>", "\[Rule]", 
+     RowBox[{"\[LeftAssociation]", 
+      RowBox[{
+       RowBox[{"\<\"operationId\"\>", 
+        "\[Rule]", "\<\"getDirectoryFiles\"\>"}], ",", 
+       RowBox[{"\<\"summary\"\>", 
+        "\[Rule]", "\<\"lists the files in a directory\"\>"}], ",", 
+       RowBox[{"\<\"responses\"\>", "\[Rule]", 
+        RowBox[{"\[LeftAssociation]", 
+         RowBox[{"\<\"200\"\>", "\[Rule]", 
+          RowBox[{"\[LeftAssociation]", 
+           RowBox[{"\<\"description\"\>", "\[Rule]", "\<\"OK\"\>"}], 
+           "\[RightAssociation]"}]}], "\[RightAssociation]"}]}], ",", 
+       RowBox[{"\<\"parameters\"\>", "\[Rule]", 
+        RowBox[{"{", 
+         RowBox[{"\[LeftAssociation]", 
+          RowBox[{
+           RowBox[{"\<\"name\"\>", "\[Rule]", "\<\"path\"\>"}], ",", 
+           RowBox[{"\<\"in\"\>", "\[Rule]", "\<\"query\"\>"}], ",", 
+           
+           RowBox[{"\<\"description\"\>", 
+            "\[Rule]", "\<\"the path to the directory\"\>"}], ",", 
+           RowBox[{"\<\"required\"\>", "\[Rule]", "True"}], ",", 
+           RowBox[{"\<\"schema\"\>", "\[Rule]", 
+            RowBox[{"\[LeftAssociation]", 
+             RowBox[{"\<\"type\"\>", "\[Rule]", "\<\"string\"\>"}], 
+             "\[RightAssociation]"}]}]}], "\[RightAssociation]"}], "}"}]}]}], 
+      "\[RightAssociation]"}]}], "\[RightAssociation]"}]}], 
+  "\[RightAssociation]"}]], "Output",
+ CellChangeTimes->{{3.890331653482462*^9, 3.8903317161152487`*^9}, 
+   3.890357263338434*^9},
+ CellLabel->"Out[5]=",ExpressionUUID->"f8cb8051-9a26-4243-b58e-2eec72f33ca1"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginEndpoint", "[", "\n", "\t\t\t", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"f", ",", " ", "\"\<lists the files in a directory\>\""}], "}"}], 
+   ",", "\n", "\t\t\t", 
+   RowBox[{"\"\<path\>\"", " ", "->", " ", 
+    RowBox[{"<|", 
+     RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}], 
+     "|>"}]}], ",", "\n", "\t\t\t", 
+   RowBox[{
+    RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "\n", "\t\t", 
+  "]"}]], "Input",
+ CellChangeTimes->{3.890331949223948*^9},
+ CellLabel->"In[6]:=",ExpressionUUID->"af95f926-369a-4089-9f03-8626ac5ae92b"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["Failure",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected an operation name, or a list containing an \
+operation name and a prompt, but found \\!\\(\\*TagBox[RowBox[{\\\"{\\\", \
+RowBox[{\\\"f\\\", \\\",\\\", \\\"\\\\\\\"lists the files in a \
+directory\\\\\\\"\\\"}], \\\"}\\\"}], Function[Short[Slot[1], 5]]]\\) \
+instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidOperationSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"OperationSpecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"{", 
+                    RowBox[{"f", ",", "\"lists the files in a directory\""}], 
+                    "}"}], HoldForm], "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Message\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                  "\"Expected an operation name, or a list containing an \
+operation name and a prompt, but found \\!\\(\\*TagBox[RowBox[{\\\"{\\\", \
+RowBox[{\\\"f\\\", \\\",\\\", \\\"\\\\\\\"lists the files in a \
+directory\\\\\\\"\\\"}], \\\"}\\\"}], Function[Short[Slot[1], 5]]]\\) \
+instead.\"", HoldForm], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  TemplateBox[{"\"Tag\"", "\": \""}, "RowDefault"], 
+                  "SummaryItemAnnotation"], "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox["\"InvalidOperationSpecification\"", HoldForm], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                  
+                  TemplateBox[{"\"OperationSpecification\"", "\": \""}, 
+                   "RowDefault"], "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{"{", 
+                    RowBox[{"f", ",", "\"lists the files in a directory\""}], 
+                    "}"}], HoldForm], "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Failure[
+  "InvalidOperationSpecification", <|
+   "MessageTemplate" -> 
+    "Expected an operation name, or a list containing an operation name and a \
+prompt, but found `1` instead.", 
+    "MessageParameters" -> {{$CellContext`f, 
+       "lists the files in a directory"}}, 
+    "OperationSpecification" -> {$CellContext`f, 
+      "lists the files in a directory"}|>],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.89033194960677*^9, 3.89035726595268*^9},
+ CellLabel->"Out[6]=",ExpressionUUID->"67911a58-48ba-4be0-92c5-840427935cea"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginEndpoint", "[", "\[IndentingNewLine]", 
+  RowBox[{"\"\<getDirectoryFiles\>\"", ",", "\[IndentingNewLine]", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{
+     RowBox[{
+     "\"\<Prompt\>\"", "->", "\"\<lists the files in a directory\>\""}], ",", 
+     "\[IndentingNewLine]", 
+     RowBox[{"\"\<APIFunction\>\"", "->", 
+      RowBox[{"APIFunction", "[", 
+       RowBox[{
+        RowBox[{"\"\<path\>\"", " ", "->", " ", 
+         RowBox[{"<|", 
+          RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}],
+           "|>"}]}], ",", 
+        RowBox[{
+         RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "]"}]}]}], 
+    "\[IndentingNewLine]", "|>"}]}], "\[IndentingNewLine]", "]"}]], "Input",
+ CellChangeTimes->{{3.8903572922334423`*^9, 3.8903573359425297`*^9}},
+ CellLabel->"In[3]:=",ExpressionUUID->"32e00657-2772-4701-9e58-3ed83681adf6"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPluginEndpoint",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}}, 
+             AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"lists the files in a directory\"", "SummaryItem"]}]}}, 
+             AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+   "OperationID" -> "getDirectoryFiles", "Prompt" -> 
+    "lists the files in a directory", 
+    "Parameters" -> {
+     "path" -> <|
+       "Interpreter" -> "String", "Help" -> "the path to the directory", 
+        "Required" -> True|>}, "Function" -> (StringReverse[
+      Slot["path"]]& ), "OutputFormat" -> Automatic, 
+    "APIFunctionOptions" -> {}|>, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.890357336531557*^9, 3.890357436857326*^9, 
+  3.890357820751021*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"fe19a72f-4153-4bd2-aa90-ecdd0858e718"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginEndpoint", "[", "\[IndentingNewLine]", 
+  RowBox[{"\"\<getDirectoryFiles\>\"", ",", "\[IndentingNewLine]", 
+   RowBox[{"<|", "\[IndentingNewLine]", 
+    RowBox[{"\"\<APIFunction\>\"", "->", 
+     RowBox[{"APIFunction", "[", 
+      RowBox[{
+       RowBox[{"\"\<path\>\"", " ", "->", " ", 
+        RowBox[{"<|", 
+         RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}], 
+         "|>"}]}], ",", 
+       RowBox[{
+        RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "]"}]}], 
+    "\[IndentingNewLine]", "|>"}]}], "\[IndentingNewLine]", "]"}]], "Input",
+ CellChangeTimes->{{3.8903578287538757`*^9, 3.890357829223971*^9}},
+ CellLabel->"In[4]:=",ExpressionUUID->"6d4ce8b7-be90-44fe-9ab6-6214cf415be7"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPluginEndpoint",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                  "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+   "OperationID" -> "getDirectoryFiles", "Prompt" -> Missing["NotSpecified"], 
+    "Parameters" -> {
+     "path" -> <|
+       "Interpreter" -> "String", "Help" -> "the path to the directory", 
+        "Required" -> True|>}, "Function" -> (StringReverse[
+      Slot["path"]]& ), "OutputFormat" -> Automatic, 
+    "APIFunctionOptions" -> {}|>, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.8903578296715097`*^9},
+ CellLabel->"Out[4]=",ExpressionUUID->"d2dd5fdb-0a6d-4e71-8630-7222cc0c93a2"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginEndpoint", "[", 
+  RowBox[{"\"\<getDirectoryFiles\>\"", ",", 
+   RowBox[{"<|", "|>"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.890357833751333*^9, 3.890357840517674*^9}},
+ CellLabel->"In[6]:=",ExpressionUUID->"f76cb45d-7fea-40a2-a53c-9c6d12fd306e"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["Failure",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Message: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox[
+                   "\"Required an APIFunction in endpoint, but only found \\!\
+\\(\\*TagBox[RowBox[{\\\"\[LeftAssociation]\\\", \
+\\\"\[RightAssociation]\\\"}], Function[Short[Slot[1], 5]]]\\).\"", 
+                    "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}, {
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Tag: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox["\"MissingAPIFunction\"", "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}, {
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Data: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox[
+                    RowBox[{"\[LeftAssociation]", "\[RightAssociation]"}], 
+                    "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            FrameBox[
+             StyleBox["\"\[WarningSign]\"", 
+              Directive["Message", 35], StripOnInput -> False], 
+             ContentPadding -> False, FrameStyle -> None, 
+             FrameMargins -> {{0, 0}, {0, 0}}, StripOnInput -> False], 
+            GridBox[{{
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Message: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox[
+                   "\"Required an APIFunction in endpoint, but only found \\!\
+\\(\\*TagBox[RowBox[{\\\"\[LeftAssociation]\\\", \
+\\\"\[RightAssociation]\\\"}], Function[Short[Slot[1], 5]]]\\).\"", 
+                    "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}, {
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Tag: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox["\"MissingAPIFunction\"", "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}, {
+               TagBox[
+                GridBox[{{
+                   TagBox["\"Data: \"", "SummaryItemAnnotation"], 
+                   "\[InvisibleSpace]", 
+                   TagBox[
+                    RowBox[{"\[LeftAssociation]", "\[RightAssociation]"}], 
+                    "SummaryItem"]}}, 
+                 GridBoxItemSize -> {"Columns" -> {6.5, All, Automatic}}, 
+                 GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{0}}}], "SummaryItem"]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Failure[
+  "MissingAPIFunction", <|
+   "MessageTemplate" -> 
+    "Required an APIFunction in endpoint, but only found `1`.", 
+    "MessageParameters" -> {<||>}, "Data" -> <||>|>],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{{3.890357834145296*^9, 3.890357841345996*^9}},
+ CellLabel->"Out[6]=",ExpressionUUID->"44937732-1b2c-4c84-9536-203983b7411c"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  InterpretationBox[
+   RowBox[{
+    TagBox["ChatGPTPluginEndpoint",
+     "SummaryHead"], "[", 
+    DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+     TemplateBox[{
+       PaneSelectorBox[{False -> GridBox[{{
+             PaneBox[
+              ButtonBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+                ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+               BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+               Evaluator -> Automatic, Method -> "Preemptive"], 
+              Alignment -> {Center, Center}, ImageSize -> 
+              Dynamic[{
+                Automatic, 
+                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])}]], 
+             GridBox[{{
+                RowBox[{
+                  TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                  "\[InvisibleSpace]", 
+                  TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}}, 
+              AutoDelete -> False, 
+              BaseStyle -> {
+               ShowStringCharacters -> False, NumberMarks -> False, 
+                PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+              GridBoxAlignment -> {
+               "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+              GridBoxItemSize -> {
+               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+              GridBoxSpacings -> {
+               "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+           False, BaselinePosition -> {1, 1}, 
+           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+           GridBoxItemSize -> {
+            "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+         GridBox[{{
+             PaneBox[
+              ButtonBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+               Appearance -> None, BaseStyle -> {}, 
+               ButtonFunction :> (Typeset`open$$ = False), Evaluator -> 
+               Automatic, Method -> "Preemptive"], 
+              Alignment -> {Center, Center}, ImageSize -> 
+              Dynamic[{
+                Automatic, 
+                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                  Magnification])}]], 
+             GridBox[{{
+                RowBox[{
+                  TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                  "\[InvisibleSpace]", 
+                  TagBox["\"getDirectoryFiles\"", "SummaryItem"]}]}, {
+                RowBox[{
+                  TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                  "\[InvisibleSpace]", 
+                  TagBox[
+                   RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                   "SummaryItem"]}]}}, AutoDelete -> False, 
+              BaseStyle -> {
+               ShowStringCharacters -> False, NumberMarks -> False, 
+                PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+              GridBoxAlignment -> {
+               "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+              GridBoxItemSize -> {
+               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+              GridBoxSpacings -> {
+               "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+           False, BaselinePosition -> {1, 1}, 
+           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+           GridBoxItemSize -> {
+            "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+      "SummaryPanel"],
+     DynamicModuleValues:>{}], "]"}],
+   Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+    "OperationID" -> "getDirectoryFiles", "Prompt" -> Missing["NotSpecified"],
+      "Parameters" -> {
+      "path" -> <|
+        "Interpreter" -> "String", "Help" -> "the path to the directory", 
+         "Required" -> True|>}, "Function" -> (StringReverse[
+       Slot["path"]]& ), "OutputFormat" -> Automatic, 
+     "APIFunctionOptions" -> {}|>, {}],
+   Editable->False,
+   SelectWithContents->True,
+   Selectable->False], "[", "\"\<Prompt\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.890358898248118*^9, 3.890358902513754*^9}},
+ CellLabel->"In[6]:=",ExpressionUUID->"15f5ae47-1c8d-408d-b893-59c601c2ad19"],
+
+Cell[BoxData[
+ RowBox[{"Missing", "[", "\<\"NotSpecified\"\>", "]"}]], "Output",
+ CellChangeTimes->{{3.890358894169022*^9, 3.890358902754356*^9}},
+ CellLabel->"Out[6]=",ExpressionUUID->"64b69496-cc70-4093-bb8c-973e77e54fe6"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"ChatGPTPluginEndpoint", "[", 
+   RowBox[{"\"\<getDirectoryFiles\>\"", ",", 
+    RowBox[{"APIFunction", "[", 
+     RowBox[{
+      RowBox[{"\"\<path\>\"", " ", "->", " ", 
+       RowBox[{"<|", 
+        RowBox[{"\"\<Help\>\"", "->", "\"\<the path to the directory\>\""}], 
+        "|>"}]}], ",", 
+      RowBox[{
+       RowBox[{"StringReverse", "[", "#path", "]"}], "&"}]}], "]"}]}], "]"}], 
+  "[", "\"\<APIFunction\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.890357847360937*^9, 3.890357862524941*^9}, {
+  3.890357987128145*^9, 3.8903579929532757`*^9}},
+ CellLabel->"In[3]:=",ExpressionUUID->"390cdd94-d84d-42d0-96d3-0d53bce558e4"],
+
+Cell[BoxData[
+ RowBox[{"APIFunction", "[", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"\<\"path\"\>", "\[Rule]", 
+     RowBox[{"\[LeftAssociation]", 
+      RowBox[{
+       RowBox[{"\<\"Interpreter\"\>", "\[Rule]", "\<\"String\"\>"}], ",", 
+       RowBox[{"\<\"Required\"\>", "\[Rule]", "True"}]}], 
+      "\[RightAssociation]"}]}], "}"}], ",", 
+   RowBox[{
+    RowBox[{"If", "[", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"HTTPRequestData", "[", "\<\"Method\"\>", "]"}], 
+       "===", "\<\"OPTIONS\"\>"}], ",", "\<\"\"\>", ",", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         RowBox[{"StringReverse", "[", "#path", "]"}], "&"}], ")"}], "[", 
+       "#1", "]"}]}], "]"}], "&"}], ",", "Automatic", ",", 
+   RowBox[{"{", "}"}]}], "]"}]], "Output",
+ CellChangeTimes->{{3.890357851784556*^9, 3.8903578628347597`*^9}, 
+   3.890357993457014*^9, {3.8903588399085083`*^9, 3.8903588414947767`*^9}, 
+   3.890358889369548*^9, 3.890359002917066*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"5c434661-715e-4417-954e-24386bb412c7"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPlugin", "[", 
+  RowBox[{"<|", "\n", "\t", 
+   RowBox[{
+    RowBox[{"\"\<Name\>\"", " ", "->", " ", "\"\<FileOrganizer\>\""}], ",", 
+    "\[IndentingNewLine]", "\t", 
+    RowBox[{
+    "\"\<Description\>\"", " ", "->", " ", 
+     "\"\<View and organize files on a computer.\>\""}], ",", 
+    "\[IndentingNewLine]", "\t", 
+    RowBox[{
+    "\"\<Prompt\>\"", " ", "->", " ", 
+     "\"\<View and organize files on a computer.\>\""}], ",", "\n", "\t", 
+    RowBox[{"\"\<Endpoints\>\"", " ", "->", " ", 
+     RowBox[{"<|", "\n", "\t\t", 
+      RowBox[{
+       RowBox[{"\"\<getFileNames\>\"", " ", "->", " ", 
+        RowBox[{"<|", "\n", "\t\t\t", 
+         RowBox[{
+          RowBox[{
+          "\"\<Prompt\>\"", " ", "->", " ", 
+           "\"\<lists the names of the files\>\""}], ",", "\n", "\t\t\t", 
+          RowBox[{"\"\<APIFunction\>\"", " ", "->", " ", 
+           RowBox[{"APIFunction", "[", 
+            RowBox[{
+             RowBox[{"{", "}"}], ",", 
+             RowBox[{
+              RowBox[{"StringRiffle", "[", 
+               RowBox[{
+                RowBox[{"FileNameTake", "/@", 
+                 RowBox[{"FileNames", "[", 
+                  RowBox[{"\"\<*\>\"", ",", "exampleDirectory"}], "]"}]}], 
+                ",", "\"\<\\n\>\""}], "]"}], "&"}]}], "]"}]}]}], "\n", "\t\t",
+          "|>"}]}], ",", "\n", "\t\t", 
+       RowBox[{"\"\<getFileContents\>\"", " ", "->", " ", 
+        RowBox[{"<|", "\n", "\t\t\t", 
+         RowBox[{
+          RowBox[{
+          "\"\<Prompt\>\"", " ", "->", " ", 
+           "\"\<gets the contents of a file as text. Only request the \
+contents of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t", 
+          RowBox[{"\"\<APIFunction\>\"", " ", "->", " ", 
+           RowBox[{"APIFunction", "[", 
+            RowBox[{
+             RowBox[{"\"\<name\>\"", " ", "->", " ", 
+              RowBox[{"<|", 
+               RowBox[{"\"\<Help\>\"", "->", "\"\<the name of the file\>\""}],
+                "|>"}]}], ",", " ", 
+             RowBox[{
+              RowBox[{"StringRiffle", "[", 
+               RowBox[{
+                RowBox[{"FileNameTake", "/@", 
+                 RowBox[{"FileNames", "[", 
+                  RowBox[{"\"\<*\>\"", ",", "exampleDirectory"}], "]"}]}], 
+                ",", "\"\<\\n\>\""}], "]"}], "&"}]}], "]"}]}]}], "\n", "\t\t",
+          "|>"}]}], ",", "\n", "\t\t", 
+       RowBox[{"\"\<renameFile\>\"", " ", "->", " ", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"{", 
+           RowBox[{"\"\<oldName\>\"", ",", " ", "\"\<newName\>\""}], "}"}], 
+          ",", " ", 
+          RowBox[{
+           RowBox[{"RenameFile", "[", 
+            RowBox[{
+             RowBox[{"FileNameJoin", "[", 
+              RowBox[{"{", 
+               RowBox[{"exampleDirectory", ",", "#oldName"}], "}"}], "]"}], 
+             ",", " ", 
+             RowBox[{"FileNameJoin", "[", 
+              RowBox[{"{", 
+               RowBox[{"exampleDirectory", ",", "#newName"}], "}"}], "]"}]}], 
+            "]"}], "&"}]}], "]"}]}]}], "\n", "\t", "|>"}]}]}], "\n", "|>"}], 
+  "]"}]], "Code",
+ CellChangeTimes->{{3.890229392377411*^9, 3.890229585140503*^9}, {
+  3.890358583283368*^9, 3.89035859403614*^9}, {3.890358696783222*^9, 
+  3.890358712428619*^9}, {3.8903594034094*^9, 3.890359403538176*^9}},
+ CellLabel->"In[4]:=",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["ChatGPTPlugin",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
+              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"FileOrganizer\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"View and organize files on a computer.\"", 
+                  "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}], True -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
+              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"FileOrganizer\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"description: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"View and organize files on a computer.\"", 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"endpoints: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   GridBox[{{
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getFileNames\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getFileNames\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"lists the names of the files\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "getFileNames", "Prompt" -> 
+                    "lists the names of the files", "Parameters" -> {}, 
+                    "Function" -> (StringRiffle[
+                    Map[FileNameTake, 
+                    FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+                    "OutputFormat" -> Automatic, 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
+                    Editable -> False, SelectWithContents -> True]}, {
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getFileContents\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"getFileContents\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"gets the contents of a file as text. Only request the \
+contents of files that you are sure exist.\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "getFileContents", "Prompt" -> 
+                    "gets the contents of a file as text. Only request the \
+contents of files that you are sure exist.", 
+                    "Parameters" -> {
+                    "name" -> <|
+                    "Interpreter" -> "String", "Help" -> 
+                    "the name of the file", "Required" -> True|>}, 
+                    "Function" -> (StringRiffle[
+                    Map[FileNameTake, 
+                    FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+                    "OutputFormat" -> Automatic, 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
+                    Editable -> False, SelectWithContents -> True]}, {
+                    InterpretationBox[
+                    RowBox[{
+                    TagBox["ChatGPTPluginEndpoint", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"renameFile\"", "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"name: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"renameFile\"", "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"Missing", "[", "\"NotSpecified\"", "]"}], 
+                    "SummaryItem"]}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {ShowStringCharacters -> False, NumberMarks -> 
+                    False, PrintPrecision -> 3, ShowSyntaxStyles -> False}]}},
+                     GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                    
+                    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+                    "OperationID" -> "renameFile", "Prompt" -> 
+                    Missing["NotSpecified"], 
+                    "Parameters" -> {
+                    "oldName" -> <|
+                    "Interpreter" -> "String", "Help" -> 
+                    Missing["NotSpecified"], "Required" -> True|>, 
+                    "newName" -> <|
+                    "Interpreter" -> "String", "Help" -> 
+                    Missing["NotSpecified"], "Required" -> True|>}, 
+                    "Function" -> (RenameFile[
+                    FileNameJoin[{$CellContext`exampleDirectory, 
+                    Slot["oldName"]}], 
+                    FileNameJoin[{$CellContext`exampleDirectory, 
+                    Slot["newName"]}]]& ), "OutputFormat" -> Automatic, 
+                    "APIFunctionOptions" -> {}|>, {}], Selectable -> False, 
+                    Editable -> False, SelectWithContents -> True]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                   "Column"], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"prompt: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                 "\"View and organize files on a computer.\"", 
+                  "SummaryItem"]}]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
+              BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          BaselinePosition -> {1, 1}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  Wolfram`ChatGPTPluginKit`ChatGPTPlugin[<|
+   "Name" -> "FileOrganizer", "Description" -> 
+    "View and organize files on a computer.", "Prompt" -> 
+    "View and organize files on a computer."|>, {
+    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+     "OperationID" -> "getFileNames", "Prompt" -> 
+      "lists the names of the files", "Parameters" -> {}, 
+      "Function" -> (StringRiffle[
+        Map[FileNameTake, 
+         FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+      "OutputFormat" -> Automatic, "APIFunctionOptions" -> {}|>, {}], 
+    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+     "OperationID" -> "getFileContents", "Prompt" -> 
+      "gets the contents of a file as text. Only request the contents of \
+files that you are sure exist.", 
+      "Parameters" -> {
+       "name" -> <|
+         "Interpreter" -> "String", "Help" -> "the name of the file", 
+          "Required" -> True|>}, "Function" -> (StringRiffle[
+        Map[FileNameTake, 
+         FileNames["*", $CellContext`exampleDirectory]], "\n"]& ), 
+      "OutputFormat" -> Automatic, "APIFunctionOptions" -> {}|>, {}], 
+    Wolfram`ChatGPTPluginKit`ChatGPTPluginEndpoint[<|
+     "OperationID" -> "renameFile", "Prompt" -> Missing["NotSpecified"], 
+      "Parameters" -> {
+       "oldName" -> <|
+         "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
+          "Required" -> True|>, 
+        "newName" -> <|
+         "Interpreter" -> "String", "Help" -> Missing["NotSpecified"], 
+          "Required" -> True|>}, "Function" -> (RenameFile[
+        FileNameJoin[{$CellContext`exampleDirectory, 
+          Slot["oldName"]}], 
+        FileNameJoin[{$CellContext`exampleDirectory, 
+          Slot["newName"]}]]& ), "OutputFormat" -> Automatic, 
+      "APIFunctionOptions" -> {}|>, {}]}, {}],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.890359403860073*^9},
+ CellLabel->"Out[4]=",ExpressionUUID->"bc63e54e-6297-4b23-a979-5a2e83d746b1"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ChatGPTPluginDeploy", "[", 
+  RowBox[{"<|", "\n", "\t", 
+   RowBox[{
+    RowBox[{"\"\<Name\>\"", " ", "->", " ", "\"\<FileOrganizer\>\""}], ",", 
+    "\[IndentingNewLine]", "\t", 
+    RowBox[{
+    "\"\<Description\>\"", " ", "->", " ", 
+     "\"\<View and organize files on a computer.\>\""}], ",", 
+    "\[IndentingNewLine]", "\t", 
+    RowBox[{
+    "\"\<Prompt\>\"", " ", "->", " ", 
+     "\"\<View and organize files on a computer.\>\""}], ",", "\n", "\t", 
+    RowBox[{"\"\<Endpoints\>\"", " ", "->", " ", 
+     RowBox[{"<|", "\n", "\t\t", 
+      RowBox[{
+       RowBox[{"\"\<getFileNames\>\"", " ", "->", " ", 
+        RowBox[{"<|", "\n", "\t\t\t", 
+         RowBox[{
+          RowBox[{
+          "\"\<Prompt\>\"", " ", "->", " ", 
+           "\"\<lists the names of the files\>\""}], ",", "\n", "\t\t\t", 
+          RowBox[{"\"\<APIFunction\>\"", " ", "->", " ", 
+           RowBox[{"APIFunction", "[", 
+            RowBox[{
+             RowBox[{"{", "}"}], ",", 
+             RowBox[{
+              RowBox[{"StringRiffle", "[", 
+               RowBox[{
+                RowBox[{"FileNameTake", "/@", 
+                 RowBox[{"FileNames", "[", 
+                  RowBox[{"\"\<*\>\"", ",", "exampleDirectory"}], "]"}]}], 
+                ",", "\"\<\\n\>\""}], "]"}], "&"}]}], "]"}]}]}], "\n", "\t\t",
+          "|>"}]}], ",", "\n", "\t\t", 
+       RowBox[{"\"\<getFileContents\>\"", " ", "->", " ", 
+        RowBox[{"<|", "\n", "\t\t\t", 
+         RowBox[{
+          RowBox[{
+          "\"\<Prompt\>\"", " ", "->", " ", 
+           "\"\<gets the contents of a file as text. Only request the \
+contents of files that you are sure exist.\>\""}], ",", "\n", "\t\t\t", 
+          RowBox[{"\"\<APIFunction\>\"", " ", "->", " ", 
+           RowBox[{"APIFunction", "[", 
+            RowBox[{
+             RowBox[{"\"\<name\>\"", " ", "->", " ", 
+              RowBox[{"<|", 
+               RowBox[{"\"\<Help\>\"", "->", "\"\<the name of the file\>\""}],
+                "|>"}]}], ",", " ", 
+             RowBox[{
+              RowBox[{"StringRiffle", "[", 
+               RowBox[{
+                RowBox[{"FileNameTake", "/@", 
+                 RowBox[{"FileNames", "[", 
+                  RowBox[{"\"\<*\>\"", ",", "exampleDirectory"}], "]"}]}], 
+                ",", "\"\<\\n\>\""}], "]"}], "&"}]}], "]"}]}]}], "\n", "\t\t",
+          "|>"}]}], ",", "\n", "\t\t", 
+       RowBox[{"\"\<renameFile\>\"", " ", "->", " ", 
+        RowBox[{"APIFunction", "[", 
+         RowBox[{
+          RowBox[{"{", 
+           RowBox[{"\"\<oldName\>\"", ",", " ", "\"\<newName\>\""}], "}"}], 
+          ",", " ", 
+          RowBox[{
+           RowBox[{"RenameFile", "[", 
+            RowBox[{
+             RowBox[{"FileNameJoin", "[", 
+              RowBox[{"{", 
+               RowBox[{"exampleDirectory", ",", "#oldName"}], "}"}], "]"}], 
+             ",", " ", 
+             RowBox[{"FileNameJoin", "[", 
+              RowBox[{"{", 
+               RowBox[{"exampleDirectory", ",", "#newName"}], "}"}], "]"}]}], 
+            "]"}], "&"}]}], "]"}]}]}], "\n", "\t", "|>"}]}]}], "\n", "|>"}], 
+  "]"}]], "Code",
+ CellChangeTimes->{{3.890229392377411*^9, 3.890229585140503*^9}, {
+  3.890358583283368*^9, 3.89035859403614*^9}, {3.890358696783222*^9, 
+  3.890358712428619*^9}, {3.8903594034094*^9, 3.8903594107683487`*^9}},
+ CellLabel->"In[3]:=",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["SocketListener",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[{{
+               Thickness[0.041666666666666664`], {
+                FaceForm[{
+                  RGBColor[0.902, 0.902, 0.902], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}, {1, 3, 3}}}, {{{21.959, 14.8984}, {20.057, 
+                 14.281400000000001`}, {20.351, 13.3764}, {20.5, 12.4404}, {
+                 20.5, 11.5004}, {20.5, 10.5594}, {20.351, 
+                 9.624400000000001}, {20.057, 8.7184}, {21.959, 
+                 8.101400000000002}, {22.317999999999998`, 
+                 9.206400000000002}, {22.5, 10.3494}, {22.5, 11.5004}, {22.5, 
+                 12.650400000000001`}, {22.317999999999998`, 13.7944}, {
+                 21.959, 14.8984}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.9490000000000001, 0.9490000000000001, 0.9490000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{11.5, 22.5}, {11.5, 20.5}, {13.404, 20.5}, {15.231, 
+                 19.903}, {16.783, 18.773}, {17.961, 20.391}, {16.064, 
+                 21.771}, {13.83, 22.5}, {11.5, 22.5}}}]}, {
+                FaceForm[{
+                  RGBColor[0.929, 0.929, 0.929], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}}}, {{{17.9609, 20.3906}, {17.9609, 20.3906}, {
+                 16.782899999999998`, 18.7736}, {18.337899999999998`, 
+                 17.6416}, {19.4699, 16.0876}, {20.0569, 14.2816}, {21.9589, 
+                 14.898599999999998`}, {21.2409, 17.1096}, {
+                 19.857899999999997`, 19.008599999999998`}, {17.9609, 
+                 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.722, 0.722, 0.722], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 4.2266}, {5.0388, 2.6096000000000004`}, {
+                 6.9358, 1.2296000000000005`}, {9.1698, 
+                 0.49960000000000004`}, {11.4998, 0.49960000000000004`}, {
+                 11.4998, 2.4996000000000005`}, {9.5958, 
+                 2.4996000000000005`}, {7.768800000000001, 
+                 3.0966000000000005`}, {6.2168, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.7799999999999999, 0.7799999999999999, 0.7799999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{16.783199999999997`, 4.2266}, {15.231199999999998`, 
+                 3.0966000000000005`}, {13.404199999999998`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 0.49960000000000004`}, {13.830199999999998`, 
+                 0.49960000000000004`}, {16.064199999999996`, 
+                 1.2296000000000005`}, {17.961199999999998`, 
+                 2.6096000000000004`}, {16.783199999999997`, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.8510000000000001, 0.8510000000000001, 0.8510000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{20.0566, 8.718699999999998}, {19.4696, 
+                 6.911699999999998}, {18.3376, 5.358699999999999}, {16.7836, 
+                 4.226699999999998}, {17.9606, 2.6096999999999984`}, {19.8586,
+                  3.9906999999999986`}, {21.2416, 5.890699999999999}, {
+                 21.9586, 8.101699999999997}, {20.0566, 
+                 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.6749999999999999, 0.6749999999999999, 0.6749999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{2.9434, 8.718699999999998}, {1.0414, 
+                 8.101699999999997}, {1.7584, 5.890699999999999}, {3.1414, 
+                 3.9906999999999986`}, {5.0394, 2.6096999999999984`}, {6.2164,
+                  4.226699999999998}, {4.6624, 5.358699999999999}, {3.5304, 
+                 6.911699999999998}, {2.9434, 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[0.537, 0.537, 0.537], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 18.7734}, {5.0388, 20.3904}, {6.9358, 
+                 21.7704}, {9.1698, 22.5004}, {11.4998, 22.5004}, {11.4998, 
+                 20.5004}, {9.5958, 20.5004}, {7.768800000000001, 
+                 19.903399999999998`}, {6.2168, 18.7734}}}]}, {
+                FaceForm[{
+                  RGBColor[0.584, 0.584, 0.584], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{5.0391, 20.3906}, {3.1421, 19.008599999999998`}, {
+                 1.7591, 17.1096}, {1.0411000000000006`, 
+                 14.898599999999998`}, {2.9431000000000007`, 14.2816}, {
+                 3.5301000000000005`, 16.0876}, {4.662100000000001, 
+                 17.6416}, {6.2171, 18.7736}, {5.0391, 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.631, 0.631, 0.631], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {
+                 1, 3, 3}, {0, 1, 0}}}, {{{1.041, 14.8984}, {
+                 0.6819999999999999, 13.7944}, {0.4999999999999999, 
+                 12.650400000000001`}, {0.4999999999999999, 11.5004}, {
+                 0.4999999999999999, 10.3494}, {0.6819999999999999, 
+                 9.206400000000002}, {1.041, 8.101400000000002}, {
+                 2.9429999999999996`, 8.7184}, {2.649, 9.624400000000001}, {
+                 2.5, 10.5594}, {2.5, 11.5004}, {2.5, 12.4404}, {2.649, 
+                 13.3764}, {2.9429999999999996`, 14.281400000000001`}, {1.041,
+                  14.8984}}}]}}, 
+              InsetBox[
+               GraphicsBox[
+                GeometricTransformationBox[{
+                  FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}], {
+                   FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}, 
+                  FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}, {{{1, 0}, {0, -1}}, Center}], 
+                BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30, 
+                PlotRange -> {{20, 80}, {0, 70}}], 
+               Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
+               15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"127.0.0.1\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Messages: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  DynamicBox[
+                   ToBoxes[
+                    If[
+                    TrueQ[
+                    AssociationQ[ZeroMQLink`PackageScope`$SocketListeners]], 
+                    Replace[
+                    ZeroMQLink`PackageScope`safeSocketProperty[
+                    ZeroMQLink`PackageScope`$SocketListeners, 
+                    3610716040175539680], {
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
+                    Blank[Association]] :> 
+                    ZeroMQLink`PackageScope`listenerMessageCount[
+                    ZeroMQLink`Graphic`PackagePrivate`listener], 
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
+                    Blank[]] :> Missing["NotAvailable"]}], 
+                    Missing["NotAvailable"]], StandardForm], 
+                   ImageSizeCache -> {109., {2., 8.150390625}}, 
+                   TrackedSymbols :> {
+                    ZeroMQLink`PackageScope`$SocketListeners}], 
+                  "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[{{
+               Thickness[0.041666666666666664`], {
+                FaceForm[{
+                  RGBColor[0.902, 0.902, 0.902], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}, {1, 3, 3}}}, {{{21.959, 14.8984}, {20.057, 
+                 14.281400000000001`}, {20.351, 13.3764}, {20.5, 12.4404}, {
+                 20.5, 11.5004}, {20.5, 10.5594}, {20.351, 
+                 9.624400000000001}, {20.057, 8.7184}, {21.959, 
+                 8.101400000000002}, {22.317999999999998`, 
+                 9.206400000000002}, {22.5, 10.3494}, {22.5, 11.5004}, {22.5, 
+                 12.650400000000001`}, {22.317999999999998`, 13.7944}, {
+                 21.959, 14.8984}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.9490000000000001, 0.9490000000000001, 0.9490000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{11.5, 22.5}, {11.5, 20.5}, {13.404, 20.5}, {15.231, 
+                 19.903}, {16.783, 18.773}, {17.961, 20.391}, {16.064, 
+                 21.771}, {13.83, 22.5}, {11.5, 22.5}}}]}, {
+                FaceForm[{
+                  RGBColor[0.929, 0.929, 0.929], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}}}, {{{17.9609, 20.3906}, {17.9609, 20.3906}, {
+                 16.782899999999998`, 18.7736}, {18.337899999999998`, 
+                 17.6416}, {19.4699, 16.0876}, {20.0569, 14.2816}, {21.9589, 
+                 14.898599999999998`}, {21.2409, 17.1096}, {
+                 19.857899999999997`, 19.008599999999998`}, {17.9609, 
+                 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.722, 0.722, 0.722], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 4.2266}, {5.0388, 2.6096000000000004`}, {
+                 6.9358, 1.2296000000000005`}, {9.1698, 
+                 0.49960000000000004`}, {11.4998, 0.49960000000000004`}, {
+                 11.4998, 2.4996000000000005`}, {9.5958, 
+                 2.4996000000000005`}, {7.768800000000001, 
+                 3.0966000000000005`}, {6.2168, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.7799999999999999, 0.7799999999999999, 0.7799999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{16.783199999999997`, 4.2266}, {15.231199999999998`, 
+                 3.0966000000000005`}, {13.404199999999998`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 0.49960000000000004`}, {13.830199999999998`, 
+                 0.49960000000000004`}, {16.064199999999996`, 
+                 1.2296000000000005`}, {17.961199999999998`, 
+                 2.6096000000000004`}, {16.783199999999997`, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.8510000000000001, 0.8510000000000001, 0.8510000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{20.0566, 8.718699999999998}, {19.4696, 
+                 6.911699999999998}, {18.3376, 5.358699999999999}, {16.7836, 
+                 4.226699999999998}, {17.9606, 2.6096999999999984`}, {19.8586,
+                  3.9906999999999986`}, {21.2416, 5.890699999999999}, {
+                 21.9586, 8.101699999999997}, {20.0566, 
+                 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.6749999999999999, 0.6749999999999999, 0.6749999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{2.9434, 8.718699999999998}, {1.0414, 
+                 8.101699999999997}, {1.7584, 5.890699999999999}, {3.1414, 
+                 3.9906999999999986`}, {5.0394, 2.6096999999999984`}, {6.2164,
+                  4.226699999999998}, {4.6624, 5.358699999999999}, {3.5304, 
+                 6.911699999999998}, {2.9434, 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[0.537, 0.537, 0.537], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 18.7734}, {5.0388, 20.3904}, {6.9358, 
+                 21.7704}, {9.1698, 22.5004}, {11.4998, 22.5004}, {11.4998, 
+                 20.5004}, {9.5958, 20.5004}, {7.768800000000001, 
+                 19.903399999999998`}, {6.2168, 18.7734}}}]}, {
+                FaceForm[{
+                  RGBColor[0.584, 0.584, 0.584], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{5.0391, 20.3906}, {3.1421, 19.008599999999998`}, {
+                 1.7591, 17.1096}, {1.0411000000000006`, 
+                 14.898599999999998`}, {2.9431000000000007`, 14.2816}, {
+                 3.5301000000000005`, 16.0876}, {4.662100000000001, 
+                 17.6416}, {6.2171, 18.7736}, {5.0391, 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.631, 0.631, 0.631], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {
+                 1, 3, 3}, {0, 1, 0}}}, {{{1.041, 14.8984}, {
+                 0.6819999999999999, 13.7944}, {0.4999999999999999, 
+                 12.650400000000001`}, {0.4999999999999999, 11.5004}, {
+                 0.4999999999999999, 10.3494}, {0.6819999999999999, 
+                 9.206400000000002}, {1.041, 8.101400000000002}, {
+                 2.9429999999999996`, 8.7184}, {2.649, 9.624400000000001}, {
+                 2.5, 10.5594}, {2.5, 11.5004}, {2.5, 12.4404}, {2.649, 
+                 13.3764}, {2.9429999999999996`, 14.281400000000001`}, {1.041,
+                  14.8984}}}]}}, 
+              InsetBox[
+               GraphicsBox[
+                GeometricTransformationBox[{
+                  FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}], {
+                   FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}, 
+                  FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}, {{{1, 0}, {0, -1}}, Center}], 
+                BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30, 
+                PlotRange -> {{20, 80}, {0, 70}}], 
+               Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
+               15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"127.0.0.1\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Messages: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  DynamicBox[
+                   ToBoxes[
+                    If[
+                    TrueQ[
+                    AssociationQ[ZeroMQLink`PackageScope`$SocketListeners]], 
+                    Replace[
+                    ZeroMQLink`PackageScope`safeSocketProperty[
+                    ZeroMQLink`PackageScope`$SocketListeners, 
+                    3610716040175539680], {
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
+                    Blank[Association]] :> 
+                    ZeroMQLink`PackageScope`listenerMessageCount[
+                    ZeroMQLink`Graphic`PackagePrivate`listener], 
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
+                    Blank[]] :> Missing["NotAvailable"]}], 
+                    Missing["NotAvailable"]], StandardForm], 
+                   ImageSizeCache -> {109., {2., 8.150390625}}, 
+                   TrackedSymbols :> {
+                    ZeroMQLink`PackageScope`$SocketListeners}], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"HandlerFunctions: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{
+                    RowBox[{"Module", "[", 
+                    RowBox[{
+                    RowBox[{"{", 
+                    
+                    RowBox[{
+                    "Wolfram`ChatGPTPluginKit`Deploy`Private`handlers$", ",", 
+                    
+                    RowBox[{"\[LeftSkeleton]", "52", "\[RightSkeleton]"}], 
+                    ",", 
+                    RowBox[{"\[LeftSkeleton]", "44", "\[RightSkeleton]"}], 
+                    ",", 
+                    RowBox[{"\[LeftSkeleton]", "45", "\[RightSkeleton]"}]}], 
+                    "}"}], ",", 
+                    RowBox[{"\[LeftSkeleton]", "1", "\[RightSkeleton]"}]}], 
+                    "]"}], "&"}], Short], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                 "\"HandlerFunctionsKeys: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  
+                  TemplateBox[{
+                   ", ", "\", \"", "\"Timestamp\"", "\"Socket\"", 
+                    "\"SourceSocket\"", "\"Data\""}, "RowWithSeparators"], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"CharacterEncoding: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"UTF-8\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"RecordSeparators: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["None", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Socket: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  InterpretationBox[
+                   RowBox[{
+                    TagBox["SocketObject", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GraphicsBox[
+                    GeometricTransformationBox[{{{
+                    FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}]}, {{
+                    FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
+                    ImageSize -> {Automatic, 
+                    Dynamic[
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])]}, PlotRange -> {{20, 80}, {0, 70}}, 
+                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
+                    
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"Local IPAddress: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"127.0.0.1\"", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Local Port: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["18000", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    TemplateBox[{"\"TCP\"", 
+                    TagBox[
+                    "\" (Server)\"", Deploy, DefaultBaseStyle -> "Deploy"]}, 
+                    "RowDefault"], "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44\"", 
+                    "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {
+                    ShowStringCharacters -> False, NumberMarks -> False, 
+                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GraphicsBox[
+                    GeometricTransformationBox[{{{
+                    FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}]}, {{
+                    FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
+                    ImageSize -> {Automatic, 
+                    Dynamic[
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])]}, PlotRange -> {{20, 80}, {0, 70}}, 
+                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
+                    
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"Local IPAddress: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"127.0.0.1\"", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Local Port: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["18000", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    TemplateBox[{"\"TCP\"", 
+                    TagBox[
+                    "\" (Server)\"", Deploy, DefaultBaseStyle -> "Deploy"]}, 
+                    "RowDefault"], "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44\"", 
+                    "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
+                    
+                    RowBox[{
+                    TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"{", "}"}], "SummaryItem"]}], "\[SpanFromLeft]", 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {
+                    ShowStringCharacters -> False, NumberMarks -> False, 
+                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                   SocketObject[
+                   "TCPSERVER-1e4ab710-4449-42e8-a85a-d631e8115d44"], 
+                   Editable -> False, SelectWithContents -> True, Selectable -> 
+                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  SocketListener[3610716040175539680],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.8903594118373632`*^9, 3.890359479216567*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"a63136f8-7c3f-4fcf-a5d7-3d01c1ef6104"]
+}, Open  ]],
+
+Cell[BoxData[
+ RowBox[{"DeleteObject", "[", "%", "]"}]], "Input",
+ CellChangeTimes->{{3.8903594799535027`*^9, 3.890359486794615*^9}},
+ CellLabel->"In[4]:=",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
+
+Cell[BoxData[
+ RowBox[{"HandlerFunctions", "->", 
+  RowBox[{"<|", 
+   RowBox[{
+    RowBox[{"\"\<HTTPRequestReceived\>\"", "->", "Echo"}], ",", 
+    RowBox[{"\"\<HTTPResponseSent\>\"", "->", "Echo"}]}], "|>"}]}]], "Input",E\
+xpressionUUID->"2fe2361c-9ce4-45c0-8268-d6b79954fa52"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"server", "=", 
+  RowBox[{"ChatGPTPluginDeploy", "[", 
+   RowBox[{"<|", 
+    RowBox[{"\"\<Endpoints\>\"", "->", 
+     RowBox[{"<|", 
+      RowBox[{"\"\<cityPopulation\>\"", "->", 
+       RowBox[{"APIFunction", "[", 
+        RowBox[{
+         RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+         RowBox[{
+          RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}], ",", 
+         RowBox[{"{", 
+          RowBox[{"\"\<WL\>\"", ",", "\"\<HTML\>\""}], "}"}]}], "]"}]}], 
+      "|>"}]}], "|>"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.8903595260944*^9, 3.8903595870661297`*^9}, {
+   3.89035994845609*^9, 3.890359949969782*^9}, 3.890359987081604*^9, {
+   3.890360132212964*^9, 3.890360180175056*^9}, {3.8903602699972754`*^9, 
+   3.890360286639093*^9}, {3.890360348731464*^9, 3.890360349039323*^9}},
+ CellLabel->"In[11]:=",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["SocketListener",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[{{
+               Thickness[0.041666666666666664`], {
+                FaceForm[{
+                  RGBColor[0.902, 0.902, 0.902], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}, {1, 3, 3}}}, {{{21.959, 14.8984}, {20.057, 
+                 14.281400000000001`}, {20.351, 13.3764}, {20.5, 12.4404}, {
+                 20.5, 11.5004}, {20.5, 10.5594}, {20.351, 
+                 9.624400000000001}, {20.057, 8.7184}, {21.959, 
+                 8.101400000000002}, {22.317999999999998`, 
+                 9.206400000000002}, {22.5, 10.3494}, {22.5, 11.5004}, {22.5, 
+                 12.650400000000001`}, {22.317999999999998`, 13.7944}, {
+                 21.959, 14.8984}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.9490000000000001, 0.9490000000000001, 0.9490000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{11.5, 22.5}, {11.5, 20.5}, {13.404, 20.5}, {15.231, 
+                 19.903}, {16.783, 18.773}, {17.961, 20.391}, {16.064, 
+                 21.771}, {13.83, 22.5}, {11.5, 22.5}}}]}, {
+                FaceForm[{
+                  RGBColor[0.929, 0.929, 0.929], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}}}, {{{17.9609, 20.3906}, {17.9609, 20.3906}, {
+                 16.782899999999998`, 18.7736}, {18.337899999999998`, 
+                 17.6416}, {19.4699, 16.0876}, {20.0569, 14.2816}, {21.9589, 
+                 14.898599999999998`}, {21.2409, 17.1096}, {
+                 19.857899999999997`, 19.008599999999998`}, {17.9609, 
+                 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.722, 0.722, 0.722], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 4.2266}, {5.0388, 2.6096000000000004`}, {
+                 6.9358, 1.2296000000000005`}, {9.1698, 
+                 0.49960000000000004`}, {11.4998, 0.49960000000000004`}, {
+                 11.4998, 2.4996000000000005`}, {9.5958, 
+                 2.4996000000000005`}, {7.768800000000001, 
+                 3.0966000000000005`}, {6.2168, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.7799999999999999, 0.7799999999999999, 0.7799999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{16.783199999999997`, 4.2266}, {15.231199999999998`, 
+                 3.0966000000000005`}, {13.404199999999998`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 0.49960000000000004`}, {13.830199999999998`, 
+                 0.49960000000000004`}, {16.064199999999996`, 
+                 1.2296000000000005`}, {17.961199999999998`, 
+                 2.6096000000000004`}, {16.783199999999997`, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.8510000000000001, 0.8510000000000001, 0.8510000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{20.0566, 8.718699999999998}, {19.4696, 
+                 6.911699999999998}, {18.3376, 5.358699999999999}, {16.7836, 
+                 4.226699999999998}, {17.9606, 2.6096999999999984`}, {19.8586,
+                  3.9906999999999986`}, {21.2416, 5.890699999999999}, {
+                 21.9586, 8.101699999999997}, {20.0566, 
+                 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.6749999999999999, 0.6749999999999999, 0.6749999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{2.9434, 8.718699999999998}, {1.0414, 
+                 8.101699999999997}, {1.7584, 5.890699999999999}, {3.1414, 
+                 3.9906999999999986`}, {5.0394, 2.6096999999999984`}, {6.2164,
+                  4.226699999999998}, {4.6624, 5.358699999999999}, {3.5304, 
+                 6.911699999999998}, {2.9434, 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[0.537, 0.537, 0.537], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 18.7734}, {5.0388, 20.3904}, {6.9358, 
+                 21.7704}, {9.1698, 22.5004}, {11.4998, 22.5004}, {11.4998, 
+                 20.5004}, {9.5958, 20.5004}, {7.768800000000001, 
+                 19.903399999999998`}, {6.2168, 18.7734}}}]}, {
+                FaceForm[{
+                  RGBColor[0.584, 0.584, 0.584], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{5.0391, 20.3906}, {3.1421, 19.008599999999998`}, {
+                 1.7591, 17.1096}, {1.0411000000000006`, 
+                 14.898599999999998`}, {2.9431000000000007`, 14.2816}, {
+                 3.5301000000000005`, 16.0876}, {4.662100000000001, 
+                 17.6416}, {6.2171, 18.7736}, {5.0391, 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.631, 0.631, 0.631], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {
+                 1, 3, 3}, {0, 1, 0}}}, {{{1.041, 14.8984}, {
+                 0.6819999999999999, 13.7944}, {0.4999999999999999, 
+                 12.650400000000001`}, {0.4999999999999999, 11.5004}, {
+                 0.4999999999999999, 10.3494}, {0.6819999999999999, 
+                 9.206400000000002}, {1.041, 8.101400000000002}, {
+                 2.9429999999999996`, 8.7184}, {2.649, 9.624400000000001}, {
+                 2.5, 10.5594}, {2.5, 11.5004}, {2.5, 12.4404}, {2.649, 
+                 13.3764}, {2.9429999999999996`, 14.281400000000001`}, {1.041,
+                  14.8984}}}]}}, 
+              InsetBox[
+               GraphicsBox[
+                GeometricTransformationBox[{
+                  FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}], {
+                   FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}, 
+                  FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}, {{{1, 0}, {0, -1}}, Center}], 
+                BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30, 
+                PlotRange -> {{20, 80}, {0, 70}}], 
+               Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
+               15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"127.0.0.1\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Messages: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  DynamicBox[
+                   ToBoxes[
+                    If[
+                    TrueQ[
+                    AssociationQ[ZeroMQLink`PackageScope`$SocketListeners]], 
+                    Replace[
+                    ZeroMQLink`PackageScope`safeSocketProperty[
+                    ZeroMQLink`PackageScope`$SocketListeners, 
+                    3610717907711726446], {
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
+                    Blank[Association]] :> 
+                    ZeroMQLink`PackageScope`listenerMessageCount[
+                    ZeroMQLink`Graphic`PackagePrivate`listener], 
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
+                    Blank[]] :> Missing["NotAvailable"]}], 
+                    Missing["NotAvailable"]], StandardForm], 
+                   ImageSizeCache -> {7., {0., 8.}}, 
+                   TrackedSymbols :> {
+                    ZeroMQLink`PackageScope`$SocketListeners}], 
+                  "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
+              Appearance -> None, BaseStyle -> {}, 
+              ButtonFunction :> (Typeset`open$$ = False), Evaluator -> 
+              Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[{{
+               Thickness[0.041666666666666664`], {
+                FaceForm[{
+                  RGBColor[0.902, 0.902, 0.902], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}, {1, 3, 3}}}, {{{21.959, 14.8984}, {20.057, 
+                 14.281400000000001`}, {20.351, 13.3764}, {20.5, 12.4404}, {
+                 20.5, 11.5004}, {20.5, 10.5594}, {20.351, 
+                 9.624400000000001}, {20.057, 8.7184}, {21.959, 
+                 8.101400000000002}, {22.317999999999998`, 
+                 9.206400000000002}, {22.5, 10.3494}, {22.5, 11.5004}, {22.5, 
+                 12.650400000000001`}, {22.317999999999998`, 13.7944}, {
+                 21.959, 14.8984}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.9490000000000001, 0.9490000000000001, 0.9490000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{11.5, 22.5}, {11.5, 20.5}, {13.404, 20.5}, {15.231, 
+                 19.903}, {16.783, 18.773}, {17.961, 20.391}, {16.064, 
+                 21.771}, {13.83, 22.5}, {11.5, 22.5}}}]}, {
+                FaceForm[{
+                  RGBColor[0.929, 0.929, 0.929], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {
+                 1, 3, 3}}}, {{{17.9609, 20.3906}, {17.9609, 20.3906}, {
+                 16.782899999999998`, 18.7736}, {18.337899999999998`, 
+                 17.6416}, {19.4699, 16.0876}, {20.0569, 14.2816}, {21.9589, 
+                 14.898599999999998`}, {21.2409, 17.1096}, {
+                 19.857899999999997`, 19.008599999999998`}, {17.9609, 
+                 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.722, 0.722, 0.722], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 4.2266}, {5.0388, 2.6096000000000004`}, {
+                 6.9358, 1.2296000000000005`}, {9.1698, 
+                 0.49960000000000004`}, {11.4998, 0.49960000000000004`}, {
+                 11.4998, 2.4996000000000005`}, {9.5958, 
+                 2.4996000000000005`}, {7.768800000000001, 
+                 3.0966000000000005`}, {6.2168, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.7799999999999999, 0.7799999999999999, 0.7799999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{16.783199999999997`, 4.2266}, {15.231199999999998`, 
+                 3.0966000000000005`}, {13.404199999999998`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 2.4996000000000005`}, {11.500199999999996`, 
+                 0.49960000000000004`}, {13.830199999999998`, 
+                 0.49960000000000004`}, {16.064199999999996`, 
+                 1.2296000000000005`}, {17.961199999999998`, 
+                 2.6096000000000004`}, {16.783199999999997`, 4.2266}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.8510000000000001, 0.8510000000000001, 0.8510000000000001], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{20.0566, 8.718699999999998}, {19.4696, 
+                 6.911699999999998}, {18.3376, 5.358699999999999}, {16.7836, 
+                 4.226699999999998}, {17.9606, 2.6096999999999984`}, {19.8586,
+                  3.9906999999999986`}, {21.2416, 5.890699999999999}, {
+                 21.9586, 8.101699999999997}, {20.0566, 
+                 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[
+                  0.6749999999999999, 0.6749999999999999, 0.6749999999999999], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{2.9434, 8.718699999999998}, {1.0414, 
+                 8.101699999999997}, {1.7584, 5.890699999999999}, {3.1414, 
+                 3.9906999999999986`}, {5.0394, 2.6096999999999984`}, {6.2164,
+                  4.226699999999998}, {4.6624, 5.358699999999999}, {3.5304, 
+                 6.911699999999998}, {2.9434, 8.718699999999998}}}]}, {
+                FaceForm[{
+                  RGBColor[0.537, 0.537, 0.537], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 
+                 3}}}, {{{6.2168, 18.7734}, {5.0388, 20.3904}, {6.9358, 
+                 21.7704}, {9.1698, 22.5004}, {11.4998, 22.5004}, {11.4998, 
+                 20.5004}, {9.5958, 20.5004}, {7.768800000000001, 
+                 19.903399999999998`}, {6.2168, 18.7734}}}]}, {
+                FaceForm[{
+                  RGBColor[0.584, 0.584, 0.584], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                 0}}}, {{{5.0391, 20.3906}, {3.1421, 19.008599999999998`}, {
+                 1.7591, 17.1096}, {1.0411000000000006`, 
+                 14.898599999999998`}, {2.9431000000000007`, 14.2816}, {
+                 3.5301000000000005`, 16.0876}, {4.662100000000001, 
+                 17.6416}, {6.2171, 18.7736}, {5.0391, 20.3906}}}]}, {
+                FaceForm[{
+                  RGBColor[0.631, 0.631, 0.631], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {
+                 1, 3, 3}, {0, 1, 0}}}, {{{1.041, 14.8984}, {
+                 0.6819999999999999, 13.7944}, {0.4999999999999999, 
+                 12.650400000000001`}, {0.4999999999999999, 11.5004}, {
+                 0.4999999999999999, 10.3494}, {0.6819999999999999, 
+                 9.206400000000002}, {1.041, 8.101400000000002}, {
+                 2.9429999999999996`, 8.7184}, {2.649, 9.624400000000001}, {
+                 2.5, 10.5594}, {2.5, 11.5004}, {2.5, 12.4404}, {2.649, 
+                 13.3764}, {2.9429999999999996`, 14.281400000000001`}, {1.041,
+                  14.8984}}}]}}, 
+              InsetBox[
+               GraphicsBox[
+                GeometricTransformationBox[{
+                  FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}], {
+                   FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}], 
+                   FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}, 
+                  FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}], 
+                  FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}, {{{1, 0}, {0, -1}}, Center}], 
+                BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30, 
+                PlotRange -> {{20, 80}, {0, 70}}], 
+               Scaled[{0.4815646584533839, 0.480603401001521}], Center, {
+               15.479525531281004`, 15.479525531281007`}, {{1., 0.}, {0., 
+               1.}}]}, AspectRatio -> Automatic, 
+             ImagePadding -> {{0., 0.}, {0., 0.}}, ImageSize -> {Automatic, 
+               Dynamic[
+               3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])]}, PlotRange -> {{0., 24.}, {0., 24.}}, 
+             PlotRangePadding -> Automatic], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"127.0.0.1\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Messages: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  DynamicBox[
+                   ToBoxes[
+                    If[
+                    TrueQ[
+                    AssociationQ[ZeroMQLink`PackageScope`$SocketListeners]], 
+                    Replace[
+                    ZeroMQLink`PackageScope`safeSocketProperty[
+                    ZeroMQLink`PackageScope`$SocketListeners, 
+                    3610717907711726446], {
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`listener, 
+                    Blank[Association]] :> 
+                    ZeroMQLink`PackageScope`listenerMessageCount[
+                    ZeroMQLink`Graphic`PackagePrivate`listener], 
+                    Pattern[ZeroMQLink`Graphic`PackagePrivate`a, 
+                    Blank[]] :> Missing["NotAvailable"]}], 
+                    Missing["NotAvailable"]], StandardForm], 
+                   TrackedSymbols :> {
+                    ZeroMQLink`PackageScope`$SocketListeners}], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"HandlerFunctions: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TagBox[
+                   RowBox[{
+                    RowBox[{"Module", "[", 
+                    RowBox[{
+                    RowBox[{"{", 
+                    
+                    RowBox[{
+                    "Wolfram`ChatGPTPluginKit`Deploy`Private`handlers$", ",", 
+                    
+                    RowBox[{"\[LeftSkeleton]", "52", "\[RightSkeleton]"}], 
+                    ",", 
+                    RowBox[{"\[LeftSkeleton]", "44", "\[RightSkeleton]"}], 
+                    ",", 
+                    RowBox[{"\[LeftSkeleton]", "45", "\[RightSkeleton]"}]}], 
+                    "}"}], ",", 
+                    RowBox[{"\[LeftSkeleton]", "1", "\[RightSkeleton]"}]}], 
+                    "]"}], "&"}], Short], "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox[
+                 "\"HandlerFunctionsKeys: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  
+                  TemplateBox[{
+                   ", ", "\", \"", "\"Timestamp\"", "\"Socket\"", 
+                    "\"SourceSocket\"", "\"Data\""}, "RowWithSeparators"], 
+                  "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"CharacterEncoding: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["\"UTF-8\"", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"RecordSeparators: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["None", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Socket: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  InterpretationBox[
+                   RowBox[{
+                    TagBox["SocketObject", "SummaryHead"], "[", 
+                    
+                    DynamicModuleBox[{
+                    Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxOpener"]], 
+                    ButtonFunction :> (Typeset`open$$ = True), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GraphicsBox[
+                    GeometricTransformationBox[{{{
+                    FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}]}, {{
+                    FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
+                    ImageSize -> {Automatic, 
+                    Dynamic[
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])]}, PlotRange -> {{20, 80}, {0, 70}}, 
+                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
+                    
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"Local IPAddress: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"127.0.0.1\"", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Local Port: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["18000", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    TemplateBox[{"\"TCP\"", 
+                    TagBox[
+                    "\" (Server)\"", Deploy, DefaultBaseStyle -> "Deploy"]}, 
+                    "RowDefault"], "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5\"", 
+                    "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {
+                    ShowStringCharacters -> False, NumberMarks -> False, 
+                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}], True -> GridBox[{{
+                    PaneBox[
+                    ButtonBox[
+                    DynamicBox[
+                    FEPrivate`FrontEndResource[
+                    "FEBitmaps", "SummaryBoxCloser"]], 
+                    ButtonFunction :> (Typeset`open$$ = False), Appearance -> 
+                    None, BaseStyle -> {}, Evaluator -> Automatic, Method -> 
+                    "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+                    Dynamic[{Automatic, 
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])}]], 
+                    GraphicsBox[
+                    GeometricTransformationBox[{{{
+                    FilledCurveBox[{{
+                    
+                    Line[{{36.558, 8.569}, {40.947, 8.569}, {40.947, 
+                    43.684000000000005`}, {36.558, 43.684000000000005`}, {
+                    36.558, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{59.053, 8.569}, {63.443, 8.569}, {63.443, 
+                    43.684000000000005`}, {59.053, 43.684000000000005`}, {
+                    59.053, 8.569}}]}}]}, {{
+                    FilledCurveBox[{{
+                    
+                    Line[{{55.487, 8.569}, {56.95, 8.569}, {56.95, 
+                    21.188000000000002`}, {55.487, 21.188000000000002`}, {
+                    55.487, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{52.562, 8.569}, {54.025, 8.569}, {54.025, 
+                    21.188000000000002`}, {52.562, 21.188000000000002`}, {
+                    52.562, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{49.636, 8.569}, {51.099000000000004`, 8.569}, {
+                    51.099000000000004`, 21.188000000000002`}, {49.636, 
+                    21.188000000000002`}, {49.636, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{46.709, 8.569}, {48.172000000000004`, 8.569}, {
+                    48.172000000000004`, 21.188000000000002`}, {46.709, 
+                    21.188000000000002`}, {46.709, 8.569}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{43.783, 8.569}, {45.246, 8.569}, {45.246, 
+                    21.188000000000002`}, {43.783, 21.188000000000002`}, {
+                    43.783, 8.569}}]}}]}}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{40.947, 4.911}, {59.787000000000006`, 4.911}, {
+                    59.787000000000006`, 6.922}, {40.947, 6.922}, {40.947, 
+                    4.911}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 31.675}, {56.678000000000004`, 31.675}, {
+                    56.678000000000004`, 39.051}, {44.057, 39.051}, {44.057, 
+                    31.675}}]}}]}, {
+                    FilledCurveBox[{{
+                    
+                    Line[{{44.057, 43.685}, {56.678000000000004`, 43.685}, {
+                    56.678000000000004`, 65.089}, {44.057, 65.089}, {44.057, 
+                    43.685}}]}}]}}}, {{{1, 0}, {0, -1}}, Center}], {
+                    ImageSize -> {Automatic, 
+                    Dynamic[
+                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                    Magnification])]}, PlotRange -> {{20, 80}, {0, 70}}, 
+                    BaseStyle -> {CacheGraphics -> False}, ImageSize -> 30}], 
+                    
+                    GridBox[{{
+                    RowBox[{
+                    TagBox["\"Local IPAddress: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["\"127.0.0.1\"", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Local Port: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox["18000", "SummaryItem"]}], 
+                    RowBox[{
+                    TagBox["\"Protocol: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    TemplateBox[{"\"TCP\"", 
+                    TagBox[
+                    "\" (Server)\"", Deploy, DefaultBaseStyle -> "Deploy"]}, 
+                    "RowDefault"], "SummaryItem"]}]}, {
+                    RowBox[{
+                    TagBox["\"UUID: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    "\"TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5\"", 
+                    "SummaryItem"]}], "\[SpanFromLeft]", "\[SpanFromLeft]"}, {
+                    
+                    RowBox[{
+                    TagBox["\"Endpoint: \"", "SummaryItemAnnotation"], 
+                    "\[InvisibleSpace]", 
+                    TagBox[
+                    RowBox[{"{", "}"}], "SummaryItem"]}], "\[SpanFromLeft]", 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+                    AutoDelete -> False, 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{2}}, "Rows" -> {{Automatic}}}, 
+                    BaseStyle -> {
+                    ShowStringCharacters -> False, NumberMarks -> False, 
+                    PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    BaselinePosition -> {1, 1}]}, 
+                    Dynamic[Typeset`open$$], ImageSize -> Automatic]}, 
+                    "SummaryPanel"], DynamicModuleValues :> {}], "]"}], 
+                   SocketObject[
+                   "TCPSERVER-7fc9e49b-fbee-4bed-9aad-a1d02d78bba5"], 
+                   Editable -> False, SelectWithContents -> True, Selectable -> 
+                   False], "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  SocketListener[3610717907711726446],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{
+  3.890359587453292*^9, {3.89035992894007*^9, 3.8903599528178463`*^9}, 
+   3.8903599894526243`*^9, 3.8903601325892887`*^9, 3.890360184189907*^9, {
+   3.890360272746563*^9, 3.890360288219729*^9}, 3.890360349557804*^9},
+ CellLabel->"Out[11]=",ExpressionUUID->"8f82033c-ded6-4e0d-9c60-b60d7430782e"]
+}, Open  ]],
+
+Cell[BoxData[
+ RowBox[{"DeleteObject", "[", "server", "]"}]], "Input",
+ CellChangeTimes->{{3.890359588116479*^9, 3.890359590726398*^9}},
+ CellLabel->"In[12]:=",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"GenerateHTTPResponse", "[", 
+   RowBox[{
+    RowBox[{"APIFunction", "[", 
+     RowBox[{
+      RowBox[{"\"\<city\>\"", "->", "\"\<City\>\""}], ",", 
+      RowBox[{
+       RowBox[{"#city", "[", "\"\<Population\>\"", "]"}], "&"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"\"\<WL\>\"", ",", "\"\<HTML\>\""}], "}"}]}], "]"}], ",", 
+    RowBox[{"HTTPRequest", "[", "\"\<localhost?city=Chicago\>\"", "]"}]}], 
+   "]"}], "[", "\"\<Body\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.8903600512918797`*^9, 3.8903600930752087`*^9}, {
+  3.8903601245180407`*^9, 3.890360125491445*^9}, {3.890360332050372*^9, 
+  3.890360339271503*^9}},
+ CellLabel->"In[9]:=",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
+}, Open  ]]
+}, Open  ]]
 },
 WindowSize->{808, 897},
-WindowMargins->{{Automatic, 223}, {Automatic, 40}},
+WindowMargins->{{Automatic, 78}, {31, Automatic}},
 FrontEndVersion->"13.2 for Mac OS X x86 (64-bit) (November 18, 2022)",
 StyleDefinitions->"Default.nb",
-ExpressionUUID->"0e9aeb7b-4274-4cec-ae19-61f8dced1559"
+ExpressionUUID->"70ebc363-7b9f-4bf8-a98e-37b9b05400eb"
 ]
 (* End of Notebook Content *)
 
@@ -276,13 +3339,76 @@ CellTagsIndex->{}
 *)
 (*NotebookFileOutline
 Notebook[{
-Cell[558, 20, 3784, 83, 490, "Code",ExpressionUUID->"e9c4bacd-e681-43f9-b751-6578ac5acfeb",
+Cell[400, 13, 3784, 83, 490, "Code",ExpressionUUID->"e9c4bacd-e681-43f9-b751-6578ac5acfeb",
  CellID->272737127],
-Cell[4345, 105, 3291, 77, 414, "Code",ExpressionUUID->"142dfd41-0736-4106-9b10-46ee44e6515c"],
-Cell[7639, 184, 3127, 75, 338, "Code",ExpressionUUID->"342dd09a-a238-44cd-be98-a2d52da02ac3"]
+Cell[4187, 98, 3344, 78, 414, "Code",ExpressionUUID->"142dfd41-0736-4106-9b10-46ee44e6515c"],
+Cell[7534, 178, 3127, 75, 338, "Code",ExpressionUUID->"342dd09a-a238-44cd-be98-a2d52da02ac3"],
+Cell[CellGroupData[{
+Cell[10686, 257, 157, 3, 67, "Section",ExpressionUUID->"d4b686a7-940b-4bf0-9466-981f2f19d172"],
+Cell[10846, 262, 177, 2, 30, "Input",ExpressionUUID->"50faaac4-34f8-4f17-b62f-8ed6dae7e0bb"],
+Cell[CellGroupData[{
+Cell[11048, 268, 154, 3, 54, "Subsection",ExpressionUUID->"3b962326-075c-49e4-a1bb-019d37658131"],
+Cell[11205, 273, 526, 15, 35, "Text",ExpressionUUID->"956860d2-cea8-4fd5-93c8-40736859d48a"],
+Cell[CellGroupData[{
+Cell[11756, 292, 350, 6, 30, "Input",ExpressionUUID->"c546cbcc-31d1-47c4-b3af-38bd39a8f3cc"],
+Cell[12109, 300, 830, 13, 34, "Output",ExpressionUUID->"d0da8156-35ac-4c2a-a64a-677141bb5bf2"]
+}, Open  ]],
+Cell[12954, 316, 151, 3, 35, "Text",ExpressionUUID->"87a8fe9d-3490-4edb-b7de-f9a7f692d0e1"],
+Cell[13108, 321, 285, 4, 30, "Input",ExpressionUUID->"836553a1-1e26-4ebe-b9e5-26468272d409"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[13430, 330, 161, 3, 54, "Subsection",ExpressionUUID->"9b30a094-3f54-42da-8ed7-ddb4e6e2de05"],
+Cell[CellGroupData[{
+Cell[13616, 337, 709, 16, 115, "Input",ExpressionUUID->"e602e4ef-30e7-4c4e-867c-be878ec0d31c"],
+Cell[14328, 355, 4162, 88, 61, "Output",ExpressionUUID->"15818a04-fb94-41d1-9647-2940b3bfa6fd"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[18527, 448, 719, 17, 115, "Input",ExpressionUUID->"12197b44-e995-487d-b88b-ff9bc26baf27"],
+Cell[19249, 467, 1702, 35, 129, "Output",ExpressionUUID->"f8cb8051-9a26-4243-b58e-2eec72f33ca1"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[20988, 507, 601, 14, 115, "Input",ExpressionUUID->"af95f926-369a-4089-9f03-8626ac5ae92b"],
+Cell[21592, 523, 5672, 121, 95, "Output",ExpressionUUID->"67911a58-48ba-4be0-92c5-840427935cea"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[27301, 649, 911, 19, 178, "Input",ExpressionUUID->"32e00657-2772-4701-9e58-3ed83681adf6"],
+Cell[28215, 670, 4345, 94, 61, "Output",ExpressionUUID->"fe19a72f-4153-4bd2-aa90-ecdd0858e718"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[32597, 769, 763, 15, 157, "Input",ExpressionUUID->"6d4ce8b7-be90-44fe-9ab6-6214cf415be7"],
+Cell[33363, 786, 4172, 88, 61, "Output",ExpressionUUID->"d2dd5fdb-0a6d-4e71-8630-7222cc0c93a2"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[37572, 879, 286, 5, 30, "Input",ExpressionUUID->"f76cb45d-7fea-40a2-a53c-9c6d12fd306e"],
+Cell[37861, 886, 5976, 119, 81, "Output",ExpressionUUID->"44937732-1b2c-4c84-9536-203983b7411c"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[43874, 1010, 4413, 92, 57, "Input",ExpressionUUID->"15f5ae47-1c8d-408d-b893-59c601c2ad19"],
+Cell[48290, 1104, 224, 3, 34, "Output",ExpressionUUID->"64b69496-cc70-4093-bb8c-973e77e54fe6"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[48551, 1112, 664, 15, 73, "Input",ExpressionUUID->"390cdd94-d84d-42d0-96d3-0d53bce558e4"],
+Cell[49218, 1129, 1031, 25, 60, "Output",ExpressionUUID->"5c434661-715e-4417-954e-24386bb412c7"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[50286, 1159, 3395, 77, 338, "Code",ExpressionUUID->"b7a70510-7228-4104-9baf-70ad768ca931"],
+Cell[53684, 1238, 21448, 409, 61, "Output",ExpressionUUID->"bc63e54e-6297-4b23-a979-5a2e83d746b1"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[75169, 1652, 3403, 77, 338, "Code",ExpressionUUID->"30f4f3a5-1509-4e70-8ec1-ffa2baad9e24"],
+Cell[78575, 1731, 39405, 762, 61, "Output",ExpressionUUID->"a63136f8-7c3f-4fcf-a5d7-3d01c1ef6104"]
+}, Open  ]],
+Cell[117995, 2496, 211, 3, 30, "Input",ExpressionUUID->"9bb77f9d-46b0-4294-a8fb-b4ca153c3e9e"],
+Cell[118209, 2501, 278, 6, 30, "Input",ExpressionUUID->"2fe2361c-9ce4-45c0-8268-d6b79954fa52"],
+Cell[CellGroupData[{
+Cell[118512, 2511, 914, 19, 94, "Input",ExpressionUUID->"228fba3e-8599-4bd1-b2cb-5dc267a30ef4"],
+Cell[119429, 2532, 39465, 764, 61, "Output",ExpressionUUID->"8f82033c-ded6-4e0d-9c60-b60d7430782e"]
+}, Open  ]],
+Cell[158909, 3299, 215, 3, 30, "Input",ExpressionUUID->"4b8ff7c0-a20c-47f0-8e4f-ed514c39163c"],
+Cell[159127, 3304, 734, 16, 52, "Input",ExpressionUUID->"cfb306b4-3e60-4e16-9d08-cdb12d029e54"]
+}, Open  ]]
+}, Open  ]]
 }
 ]
 *)
-
-(* End of internal cache information *)
 


### PR DESCRIPTION
Adds support for creating `ChatGPTPlugin` and `ChatGPTPluginEndpoint` objects with associations that incorporate information that was otherwise stored as separate arguments. This syntax is often clearer (because it uses named arguments) as well as more concise (because the redundant `ChatGPTPluginEndpoint` and `ChatGPTPlugin` heads don't have to be explicitly used).